### PR TITLE
Post-install hands off directly into bootstrap

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -106,8 +106,9 @@ GNOME + GDM are installed by archinstall. For multilib, optional NVIDIA, Kitty, 
 ./post_install.sh
 ```
 
-Then run bootstrap for the rest of the tooling. You will be prompted for profiles
-(multi-select; any combination):
+This hands off directly into bootstrap for the rest of the tooling (any arguments you
+pass to `post_install.sh` are forwarded to it) — no separate command needed. You will be
+prompted for profiles (multi-select; any combination):
 
 - **work** — shared stack + Zoom + Slack + Chrome
 - **personal** — shared stack + Steam + Discord + Firefox + Mullvad

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This README is the starting point. Detailed install notes live in [NOTES.md](NOT
 
 | Situation | What to run |
 |-----------|-------------|
-| **Brand-new Arch install** | archinstall → `./post_install.sh` → `bash scripts/bootstrap.sh` |
+| **Brand-new Arch install** | archinstall → `./post_install.sh` (chains straight into bootstrap) |
 | **Existing machine / other PC** | `bash scripts/sync.sh` |
 | **Day-to-day package updates** | `bash scripts/update-system.sh` (guarded `pacman` + `yay`) |
 | **Just re-link configs** | `bash scripts/link-dotfiles.sh` |
@@ -59,9 +59,11 @@ After first reboot, from a clone of this repo:
 ./post_install.sh
 ```
 
-Enables multilib, updates packages, optional NVIDIA (`setup-nvidia.sh`), and installs Kitty + build basics.
+Enables multilib, updates packages, optional NVIDIA (`setup-nvidia.sh`), and installs Kitty + build basics. Then hands off directly into bootstrap (step 3) — no separate command needed.
 
 ### 3. Bootstrap (full workstation)
+
+Runs automatically at the end of `post_install.sh`. To re-run it later on its own (it's idempotent):
 
 ```bash
 # Do not run with sudo

--- a/REFRESHER.md
+++ b/REFRESHER.md
@@ -156,8 +156,7 @@ bash scripts/sync.sh --cleanup           # drop old herdr/hypr/ghostty junk
 ### …set up a brand-new Arch box
 
 1. archinstall with `user_configuration.json` (set disk + creds — see NOTES)
-2. `./post_install.sh`
-3. `bash scripts/bootstrap.sh` (name, email, work|personal, NVIDIA y/n, laptop|desktop)
+2. `./post_install.sh` — chains straight into bootstrap (name, email, work|personal, NVIDIA y/n, laptop|desktop); re-run `bash scripts/bootstrap.sh` on its own later if needed
 
 ### …remember work vs personal
 

--- a/post_install.sh
+++ b/post_install.sh
@@ -5,7 +5,8 @@
 # - optionally install NVIDIA drivers (detect / saved preference / prompt)
 # - install Kitty + base tooling
 #
-# After this, run: bash scripts/bootstrap.sh
+# Hands off directly into bootstrap.sh at the end (any args are forwarded),
+# so a single run does both. Run bootstrap.sh on its own for later re-runs.
 
 set -euo pipefail
 
@@ -76,4 +77,5 @@ sudo pacman -S --needed --noconfirm kitty git base-devel linux-headers man-db
 sudo mandb
 
 echo ""
-echo "post_install complete. Next: bash scripts/bootstrap.sh"
+echo "post_install complete. Handing off to bootstrap..."
+exec bash "$SCRIPT_DIR/scripts/bootstrap.sh" "$@"


### PR DESCRIPTION
## Summary
- Fixes #7: `post_install.sh` now `exec`s straight into `scripts/bootstrap.sh` at the end (forwarding any args) instead of printing a "run this next" message.
- `bootstrap.sh` itself is untouched and remains independently re-runnable — see ADR 0001 (`docs/adr/0001-post-install-bootstrap-separation.md`) for why the two scripts stay separate rather than merging.
- README.md, NOTES.md, REFRESHER.md updated to describe the new one-command flow.

## Test plan
- [x] `bash scripts/check.sh` (shellcheck -x + bash -n) passes
- [x] `post_install.sh` runs real privileged sudo/pacman operations unconditionally, so it can't be safely exercised end-to-end in a sandbox — instead, isolated the exact new hand-off mechanism (path resolution + `exec` + arg forwarding, byte-identical to what was added) against a stub `bootstrap.sh` and confirmed both no-arg and arg-forwarding cases work correctly
- [x] Confirmed via diff that `scripts/bootstrap.sh` was not touched at all
- [x] Two-axis code review (Standards + Spec) run against issue #7; both came back clean, no fixes needed

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoLvqeeaKm6oboUNPaHrxJ