### PR TITLE
Guided pre-install preparation for a fresh archinstall config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,8 @@ dotfiles-arch/
 ├── .cursor/rules/                # Repo conventions for AI agents (this repo only — unrelated to rules/)
 ├── AGENTS.md                     # Short pointer file for agents
 ├── PACKAGES.md                   # Why each installed package exists
-├── post_install.sh               # Minimal post-archinstall (multilib, NVIDIA?, Kitty)
+├── prepare-archinstall.sh        # Guided disk/hostname/gfx_driver prep, before archinstall
+├── post_install.sh               # Minimal post-archinstall (multilib, NVIDIA?, Kitty); chains into bootstrap.sh
 ├── user_configuration.json       # archinstall 4.4 template
 └── NOTES.md                      # Install / sync notes
 ```
@@ -142,6 +143,7 @@ Shared: Kitty, tmux, Claude Code, Neovim, languages, Docker, Spotify, Obsidian, 
 
 ### Special cases
 
+- **prepare-archinstall.sh**: Run from the live ISO before archinstall, not from an installed system. Lists block devices via `lsblk` (excluding loop/optical, and `zram` specifically since it reports `TYPE=disk` too but isn't a real wipeable target), prompts for a hostname, and detects the GPU vendor via `has_nvidia_hardware`/`has_amd_gpu_hardware`/`has_intel_gpu_hardware` (`fn-lib.sh`, sourced defensively like `post_install.sh`) to propose one of the six canonical `gfx_driver` values (`archinstall/lib/hardware.py`'s `GfxDriver` enum, tag 4.4 — see `docs/research/archinstall-config-schema.md`), letting the user confirm or override. Requires typing the disk path a second time to confirm before it's willing to select it (the layout wipes the disk). Patches `disk_config.device_modifications[0].device`, `hostname`, and `profile_config.gfx_driver` into `user_configuration.json` via `python3 -c` (present on the ISO because archinstall itself needs it), preserving key order and the rest of the file untouched. `--dry-run` prints the same planned changes without writing. Never reads, writes, or references `user_credentials.json` — the LUKS/user password stays a manual step by deliberate choice.
 - **setup-git.sh**: Requires name + email args (no TTY → must pass args); writes `~/.config/git/identity` (not the shared `.gitconfig`)
 - **setup-node.sh / setup-claude.sh**: NVM at `~/.config/nvm` (checksummed install.sh, never `curl|bash`); Claude uses user-level `npm` (never `sudo npm`). `setup-claude.sh` also idempotently merges the `nvim-reveal-edit` `PostToolUse` hook into `~/.claude/settings.json` (jq, touching only `.hooks.PostToolUse`)
 - **setup-code.sh**: Installs `tmux`, `lazygit`, `lazydocker`; runs last in `run-profile-setup.sh` (after profile extras) so Cursor/Claude are already on PATH; resolves `DEFAULT_AGENT` via `resolve_default_agent` — auto-picks the one CLI installed, prompts (Enter keeps the saved choice) when both are, leaves it empty when neither is — and persists it with `write_bootstrap_config`
@@ -181,7 +183,8 @@ Shared: Kitty, tmux, Claude Code, Neovim, languages, Docker, Spotify, Obsidian, 
 - `scripts/fn-lib.sh` — package/nvm/hardware/config/AUR-scan helpers
 - `scripts/setup-gnome.sh` — theme, Pop Shell, Dash to Panel, keybindings, GPaste, AppIndicator, No Overview
 - `scripts/setup-code.sh` — tmux-based `code` launcher + `DEFAULT_AGENT` resolution
-- `user_configuration.json` — set disk device and `gfx_driver` per machine
+- `prepare-archinstall.sh` — guided disk/hostname/`gfx_driver` prep for `user_configuration.json`, run before archinstall
+- `user_configuration.json` — disk device, hostname, and `gfx_driver` per machine (set by `prepare-archinstall.sh` or by hand)
 - `NOTES.md` — WiFi, USB config, NVIDIA, sync
 
 ## Development notes

--- a/NOTES.md
+++ b/NOTES.md
@@ -67,11 +67,24 @@ Alternately, you can leverage the presaved file on http://archconfig.weekendproj
 archinstall --config-url http://archconfig.weekendproject.app/
 ```
 
-You need to set:
+**Step zero, before running archinstall:** from this repo on the USB (or a clone on the live ISO), run the guided prep script:
 
-- Disk device path in `user_configuration.json` (`disk_config.device_modifications[0].device`)
+```shell
+./prepare-archinstall.sh
+# ./prepare-archinstall.sh --dry-run   # preview the changes first
+```
+
+It lists your block devices and lets you pick the install target, prompts for a hostname, and detects (or lets you override) the graphics driver — then writes all three straight into `user_configuration.json`. It never reads, writes, or references `user_credentials.json`.
+
+You still need to set by hand:
+
+- Authentication (including the LUKS encryption password in `user_credentials.json`)
+
+Or, without the script, hand-edit `user_configuration.json` yourself:
+
+- Disk device path (`disk_config.device_modifications[0].device`)
 - Hostname
-- Authentication (including the LUKS encryption password in credentials)
+- `gfx_driver` (see [GPU / NVIDIA](#gpu--nvidia) below)
 
 ## Disk layout (preconfigured)
 
@@ -90,7 +103,7 @@ You can unmount via `umount /mnt/usb`
 
 ## GPU / NVIDIA
 
-`user_configuration.json` currently sets archinstall `gfx_driver` to **NVIDIA open** (Turing+). On AMD/Intel-only machines, change that before install, for example to `All open-source`, or pick the right driver in the archinstall UI.
+`user_configuration.json` currently sets archinstall `gfx_driver` to **NVIDIA open** (Turing+). `./prepare-archinstall.sh` detects the GPU vendor and proposes the matching value (falling back to `All open-source` if it can't tell); confirm or override it there. Without the script, change `gfx_driver` by hand before install, or pick the right driver in the archinstall UI.
 
 After install, NVIDIA packages are **not** forced:
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ This is the guarded replacement for raw `yay -Syu`: official repos via pacman, t
 Target schema matches **archinstall 4.4** (`user_configuration.json`).
 
 1. Get network (WiFi: `iwctl` — see [NOTES.md](NOTES.md)).
-2. Edit before install:
-   - Disk device: `disk_config.device_modifications[0].device` (this **wipes** the disk)
-   - Hostname, auth, LUKS password (`user_credentials.json`)
-   - `gfx_driver` — NVIDIA open by default; change for AMD/Intel
+2. Prepare `user_configuration.json` before install:
+   ```shell
+   ./prepare-archinstall.sh
+   ```
+   Guided: pick your disk from a live listing (this **wipes** it), enter a hostname, confirm the detected graphics driver. `--dry-run` previews the changes. Doesn't touch `user_credentials.json` — set auth/LUKS password there yourself, or hand-edit `user_configuration.json` directly if you skip the script.
 3. Run archinstall with the config (USB or config URL — details in [NOTES.md](NOTES.md)).
 
 Layout: **Btrfs + LUKS + Snapper**, GNOME + GDM, PipeWire, NetworkManager.
@@ -284,7 +285,8 @@ dotfiles-arch/
 ├── CLAUDE.md              ← architecture notes for AI agents
 ├── AGENTS.md              ← pointer file for Cursor / other agents
 ├── .cursor/rules/         ← repo conventions for AI agents
-├── post_install.sh        ← minimal post-archinstall
+├── prepare-archinstall.sh ← guided disk/hostname/gfx_driver prep, before archinstall
+├── post_install.sh        ← minimal post-archinstall (chains into bootstrap.sh)
 ├── user_configuration.json
 ├── scripts/
 │   ├── bootstrap.sh       # new machine

--- a/REFRESHER.md
+++ b/REFRESHER.md
@@ -155,8 +155,9 @@ bash scripts/sync.sh --cleanup           # drop old herdr/hypr/ghostty junk
 
 ### …set up a brand-new Arch box
 
-1. archinstall with `user_configuration.json` (set disk + creds — see NOTES)
-2. `./post_install.sh` — chains straight into bootstrap (name, email, work|personal, NVIDIA y/n, laptop|desktop); re-run `bash scripts/bootstrap.sh` on its own later if needed
+1. `./prepare-archinstall.sh` — picks disk/hostname/gfx_driver into `user_configuration.json`; creds still manual
+2. archinstall with `user_configuration.json` — see NOTES
+3. `./post_install.sh` — chains straight into bootstrap (name, email, work|personal, NVIDIA y/n, laptop|desktop); re-run `bash scripts/bootstrap.sh` on its own later if needed
 
 ### …remember work vs personal
 

--- a/prepare-archinstall.sh
+++ b/prepare-archinstall.sh
@@ -1,0 +1,220 @@
+#!/bin/bash
+# Guided pre-install preparation for user_configuration.json.
+#
+# Run this BEFORE archinstall, from the live ISO (this repo cloned or copied
+# to a USB alongside user_configuration.json — see NOTES.md). Prompts for
+# the target disk device, hostname, and graphics driver, then writes those
+# three fields into user_configuration.json in place.
+#
+# Does NOT touch user_credentials.json (LUKS/user password) — that stays a
+# manual step by design.
+#
+# Usage:
+#   ./prepare-archinstall.sh [--dry-run] [-h]
+#
+# Options:
+#   --dry-run   Print the changes that would be made, without writing
+#   -h, --help  Show this help
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+# Prefer shared helpers when available (GPU-detection functions in fn-lib.sh)
+if [ -r "$SCRIPT_DIR/scripts/dotheader.sh" ]; then
+  # shellcheck source=/dev/null
+  source "$SCRIPT_DIR/scripts/dotheader.sh"
+fi
+
+CONFIG_FILE="$SCRIPT_DIR/user_configuration.json"
+DRY_RUN=false
+
+usage() {
+  cat <<EOF
+Usage: ./prepare-archinstall.sh [--dry-run] [-h]
+
+Interactively prepares user_configuration.json for a fresh archinstall:
+  1. Pick the target disk from a live lsblk listing
+  2. Enter a hostname
+  3. Confirm (or override) a detected graphics driver
+
+Writes the three fields into $CONFIG_FILE in place.
+Never touches user_credentials.json — enter the LUKS password yourself.
+
+Options:
+  --dry-run   Print the changes that would be made, without writing
+  -h, --help  Show this help
+EOF
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $arg" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "Error: $CONFIG_FILE not found." >&2
+  exit 1
+fi
+
+if ! command -v python3 &>/dev/null; then
+  echo "Error: python3 is required to edit $CONFIG_FILE (present by default on the Arch ISO, since archinstall itself needs it)." >&2
+  exit 1
+fi
+
+if ! command -v lsblk &>/dev/null; then
+  echo "Error: lsblk is required to list block devices." >&2
+  exit 1
+fi
+
+# --------------------------
+# 1. Disk selection
+# --------------------------
+
+echo ""
+echo "Available block devices:"
+# -e 7,11 excludes loop and optical devices; zram is excluded separately
+# below since lsblk reports it as TYPE=disk too, even though it's RAM-backed
+# and not a real wipeable install target.
+mapfile -t DISK_LINES < <(lsblk -dpno NAME,SIZE,MODEL -e 7,11 2>/dev/null | grep -v '^/dev/zram')
+
+if ((${#DISK_LINES[@]} == 0)); then
+  echo "Error: no block devices found via lsblk." >&2
+  exit 1
+fi
+
+i=1
+for line in "${DISK_LINES[@]}"; do
+  printf "  %d) %s\n" "$i" "$line"
+  ((i++))
+done
+
+read -rp "Select target disk [1-${#DISK_LINES[@]}]: " DISK_CHOICE
+if ! [[ "$DISK_CHOICE" =~ ^[0-9]+$ ]] || ((DISK_CHOICE < 1 || DISK_CHOICE > ${#DISK_LINES[@]})); then
+  echo "Error: invalid selection." >&2
+  exit 1
+fi
+
+DISK_DEVICE="$(awk '{print $1}' <<<"${DISK_LINES[$((DISK_CHOICE - 1))]}")"
+
+echo ""
+echo "WARNING: archinstall will WIPE $DISK_DEVICE completely."
+read -rp "Type the device path again to confirm: " DISK_CONFIRM
+if [ "$DISK_CONFIRM" != "$DISK_DEVICE" ]; then
+  echo "Error: confirmation did not match — aborting without changes." >&2
+  exit 1
+fi
+
+# --------------------------
+# 2. Hostname
+# --------------------------
+
+echo ""
+read -rp "Hostname: " HOSTNAME_VALUE
+if [ -z "$HOSTNAME_VALUE" ]; then
+  echo "Error: hostname cannot be empty." >&2
+  exit 1
+fi
+
+# --------------------------
+# 3. Graphics driver
+# --------------------------
+# Canonical values (archinstall/lib/hardware.py GfxDriver enum, tag 4.4 —
+# see docs/research/archinstall-config-schema.md). Single source of truth:
+# every place below indexes into this array rather than retyping the strings.
+GFX_DRIVER_OPTIONS=(
+  "All open-source"
+  "AMD / ATI (open-source)"
+  "Intel (open-source)"
+  "Nvidia (open kernel module for newer GPUs, Turing+)"
+  "Nvidia (open-source nouveau driver)"
+  "VirtualBox (open-source)"
+)
+
+detect_gfx_driver_index() {
+  if declare -F has_nvidia_hardware &>/dev/null && has_nvidia_hardware; then
+    echo 3 # Nvidia (open kernel module for newer GPUs, Turing+)
+  elif declare -F has_amd_gpu_hardware &>/dev/null && has_amd_gpu_hardware; then
+    echo 1 # AMD / ATI (open-source)
+  elif declare -F has_intel_gpu_hardware &>/dev/null && has_intel_gpu_hardware; then
+    echo 2 # Intel (open-source)
+  else
+    echo 0 # All open-source
+  fi
+}
+
+DETECTED_INDEX="$(detect_gfx_driver_index)"
+DETECTED_DRIVER="${GFX_DRIVER_OPTIONS[$DETECTED_INDEX]}"
+
+echo ""
+echo "Detected graphics driver: $DETECTED_DRIVER"
+echo "Options:"
+echo "  1) $DETECTED_DRIVER (detected — press Enter to accept)"
+
+# Menu numbers 2+ walk the remaining options in array order (skipping the
+# one already offered as the detected default); GFX_MENU_INDEXES maps each
+# printed menu number back to its GFX_DRIVER_OPTIONS index.
+GFX_MENU_INDEXES=("$DETECTED_INDEX")
+menu_number=2
+for idx in "${!GFX_DRIVER_OPTIONS[@]}"; do
+  [[ "$idx" -eq "$DETECTED_INDEX" ]] && continue
+  printf "  %d) %s\n" "$menu_number" "${GFX_DRIVER_OPTIONS[$idx]}"
+  GFX_MENU_INDEXES+=("$idx")
+  ((menu_number++))
+done
+
+read -rp "Choose [1]: " GFX_CHOICE
+GFX_CHOICE="${GFX_CHOICE:-1}"
+if ! [[ "$GFX_CHOICE" =~ ^[0-9]+$ ]] || ((GFX_CHOICE < 1 || GFX_CHOICE > ${#GFX_MENU_INDEXES[@]})); then
+  echo "Error: invalid choice: $GFX_CHOICE" >&2
+  exit 1
+fi
+GFX_DRIVER="${GFX_DRIVER_OPTIONS[${GFX_MENU_INDEXES[$((GFX_CHOICE - 1))]}]}"
+
+# --------------------------
+# Apply
+# --------------------------
+
+echo ""
+echo "Planned changes to $CONFIG_FILE:"
+echo "  disk_config.device_modifications[0].device -> $DISK_DEVICE"
+echo "  hostname -> $HOSTNAME_VALUE"
+echo "  profile_config.gfx_driver -> $GFX_DRIVER"
+
+if [ "$DRY_RUN" = true ]; then
+  echo ""
+  echo "Dry run — no changes written."
+  exit 0
+fi
+
+python3 - "$CONFIG_FILE" "$DISK_DEVICE" "$HOSTNAME_VALUE" "$GFX_DRIVER" <<'PYEOF'
+import json
+import sys
+
+config_path, disk_device, hostname, gfx_driver = sys.argv[1:5]
+
+with open(config_path) as f:
+    config = json.load(f)
+
+config["disk_config"]["device_modifications"][0]["device"] = disk_device
+config["hostname"] = hostname
+config["profile_config"]["gfx_driver"] = gfx_driver
+
+with open(config_path, "w") as f:
+    json.dump(config, f, indent=4)
+    f.write("\n")
+PYEOF
+
+echo ""
+echo "Updated $CONFIG_FILE."
+echo "Next: run archinstall with this config (see NOTES.md)."

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -9,7 +9,7 @@ cd "$ROOT"
 
 files=()
 shopt -s nullglob
-for f in scripts/*.sh post_install.sh home/.local/bin/*; do
+for f in scripts/*.sh post_install.sh prepare-archinstall.sh home/.local/bin/*; do
   [[ -f "$f" ]] || continue
   # Skip non-shell helpers if any appear later
   case "$f" in

--- a/scripts/fn-lib.sh
+++ b/scripts/fn-lib.sh
@@ -775,6 +775,32 @@ has_intel_hardware() {
   return 1
 }
 
+# Internal: true when a PCI VGA/3D/Display controller line matches the given
+# (already word-bounded) grep -E vendor pattern. Shared by the per-vendor
+# has_*_gpu_hardware helpers below. Unlike has_nvidia_hardware, there's no
+# sysfs vendor-ID fallback when lspci is missing — these two only run from
+# prepare-archinstall.sh on the Arch live ISO, where lspci is always present
+# (archinstall itself depends on it).
+_has_gpu_vendor() {
+  local vendor_pattern="$1"
+  command -v lspci &>/dev/null || return 1
+  lspci -nn 2>/dev/null | grep -qiE "${vendor_pattern}.*(VGA|3D|Display)|(VGA|3D|Display).*${vendor_pattern}"
+}
+
+# True when an AMD/ATI GPU is visible to the system (PCI display controller
+# only — narrower than has_intel_hardware, which also matches Intel CPUs).
+# \b-bounded: "ATI" as a loose substring false-positives on ordinary words
+# like "compatible" (as in lspci's own "VGA compatible controller" text).
+has_amd_gpu_hardware() {
+  _has_gpu_vendor '\b(AMD|ATI)\b'
+}
+
+# True when an Intel GPU is visible to the system (PCI display controller
+# only — narrower than has_intel_hardware, which also matches Intel CPUs).
+has_intel_gpu_hardware() {
+  _has_gpu_vendor '\bIntel\b'
+}
+
 # --------------------------
 # Package helpers
 # --------------------------


### PR DESCRIPTION
## Summary
- Fixes #8: adds `prepare-archinstall.sh` at the repo root, run from the live ISO before archinstall — lists block devices, prompts for a hostname, detects the GPU vendor to propose a `gfx_driver` value (user can override), then patches all three into `user_configuration.json`. `--dry-run` previews without writing. Never touches `user_credentials.json`.
- Adds `has_amd_gpu_hardware`/`has_intel_gpu_hardware` to `fn-lib.sh`, narrower than the existing `has_intel_hardware` (which also matches Intel CPUs) and word-bounded to avoid a real bug: "ATI" as a loose substring false-positives on ordinary words like "compa**ti**ble" — meaning lspci's own boilerplate ("VGA compatible controller") would have made every machine misreport an AMD GPU. Caught in testing, fixed before merge.
- `NOTES.md`/`README.md`/`REFRESHER.md`/`CLAUDE.md` updated to document this as step zero, before archinstall.

## Test plan
- [x] `bash scripts/check.sh` (shellcheck -x + bash -n) passes — also extended its glob to actually cover this new root-level script, which it wasn't picking up by default
- [x] Isolated test harness (fake repo copy, stubbed `lspci`, no real system touched) covering: disk listing with `zram` correctly excluded (reports `TYPE=disk` too but isn't a real target), destructive-selection double-confirmation, empty-hostname rejection, dry-run vs. real write, GPU-vendor menu reordering across NVIDIA/AMD/Intel/unknown detection, and out-of-range menu selection
- [x] Confirmed zero functional references to `user_credentials.json` (only doc comments explaining it's out of scope)
- [x] Two-axis code review (Standards + Spec) run against issue #8; both findings addressed (duplicated `gfx_driver` strings across menu/dispatch/detection consolidated into one source-of-truth array, which also fixed a UX redundancy; duplicated vendor-detection logic extracted into a shared helper)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoLvqeeaKm6oboUNPaHrxJ