### PR TITLE
Add v1-to-v2 migration script for the dfa- command rename

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -191,6 +191,22 @@ Do this on each machine that should match the repo. Fresh installs still use `bo
 
 Paths use `$HOME` / `$USER_HOME_DIR` so different usernames on other machines work without edits.
 
+### One-time: v1 -> v2 command rename cleanup
+
+The day-to-day commands (`morning`, `sync-dotfiles`, `repos`, etc.) were renamed under a
+`dfa-` prefix. `link-dotfiles.sh` only creates symlinks for files currently in the repo —
+it never removes ones whose source got renamed away — so a machine set up before this
+rename is left with the old commands as dangling `~/.local/bin` symlinks, alongside none
+of the new `dfa-*` ones. Run this once per existing machine, then reload your shell:
+
+```shell
+bash migrations/v1-to-v2-migration.sh
+source ~/.bashrc
+```
+
+Safe to re-run; a machine that's already been migrated (or never had the old names) is a
+no-op.
+
 ## GNOME overview at login
 
 GNOME has no built-in “skip Activities at startup” setting. This repo uses:

--- a/migrations/v1-to-v2-migration.sh
+++ b/migrations/v1-to-v2-migration.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Migration: v1 -> v2 (day-to-day command rename cleanup).
+#
+# The v2 rewrite renamed ten day-to-day commands under a dfa- prefix
+# (morning -> dfa-morning, sync-dotfiles -> dfa-sync-dotfiles, etc. — see
+# CLAUDE.md). scripts/link-dotfiles.sh only creates symlinks for files
+# currently in the repo; it never prunes ones whose source got renamed
+# away. So a machine set up before the rename is left with ten dangling
+# ~/.local/bin symlinks pointing at files that no longer exist, and none of
+# the new dfa-* symlinks yet.
+#
+# Run this once on any such existing machine to clean that up: it removes
+# the dangling old-named symlinks (only if they're genuinely dangling —
+# anything that still resolves, or isn't a symlink, is left alone) and
+# relinks dotfiles to create the new dfa-* commands. Safe to re-run.
+#
+# Usage: bash migrations/v1-to-v2-migration.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." &>/dev/null && pwd)"
+
+if [ -r "$REPO_ROOT/scripts/dotheader.sh" ]; then
+  # shellcheck source=/dev/null
+  source "$REPO_ROOT/scripts/dotheader.sh"
+else
+  echo "Missing header file: $REPO_ROOT/scripts/dotheader.sh"
+  exit 1
+fi
+
+BIN_DIR="$USER_HOME_DIR/.local/bin"
+
+# The ten day-to-day commands renamed with a dfa- prefix (see CLAUDE.md).
+OLD_NAMES=(
+  morning
+  sync-dotfiles
+  repos
+  update-repos
+  update-system
+  check-dotfiles
+  remove-orphans
+  sync-skills
+  sync-rules
+  sync-sources
+)
+
+print_line_break "v1 -> v2 migration: dfa- command rename cleanup"
+
+removed=0
+for name in "${OLD_NAMES[@]}"; do
+  target="$BIN_DIR/$name"
+  if [ -L "$target" ] && [ ! -e "$target" ]; then
+    print_info_message "Removing dangling symlink: $target"
+    rm "$target"
+    removed=$((removed + 1))
+  elif [ -e "$target" ] || [ -L "$target" ]; then
+    print_warning_message "Skipping $target — not a dangling symlink (still resolves, or isn't a symlink); leaving it alone"
+  fi
+  # else: nothing there — already migrated (or never existed) — skip silently
+done
+
+if ((removed == 0)); then
+  print_info_message "No dangling pre-rename symlinks found."
+else
+  print_info_message "Removed $removed dangling symlink(s)."
+fi
+
+print_info_message "Relinking dotfiles to create the new dfa-* commands..."
+bash "$REPO_ROOT/scripts/link-dotfiles.sh"
+
+print_line_break "Migration complete"
+print_info_message "Run 'source ~/.bashrc' (or open a new terminal) to pick up the updated aliases."

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -9,7 +9,7 @@ cd "$ROOT"
 
 files=()
 shopt -s nullglob
-for f in scripts/*.sh post_install.sh prepare-archinstall.sh home/.local/bin/*; do
+for f in scripts/*.sh post_install.sh prepare-archinstall.sh migrations/*.sh home/.local/bin/*; do
   [[ -f "$f" ]] || continue
   # Skip non-shell helpers if any appear later
   case "$f" in


### PR DESCRIPTION
## Summary
- `link-dotfiles.sh` only creates symlinks for files currently in the repo; it never prunes ones whose source got renamed away. The dfa- prefix rename (#6) left any existing machine with ten dangling `~/.local/bin` symlinks (`morning`, `sync-dotfiles`, `repos`, etc.) and none of the new `dfa-*` ones.
- Adds `migrations/v1-to-v2-migration.sh`: removes the old dangling symlinks (only ones genuinely dangling — anything that still resolves, or isn't a symlink, is left alone) and re-runs `scripts/link-dotfiles.sh` to create the new commands. Safe to re-run.
- `scripts/check.sh`'s lint glob extended to cover `migrations/*.sh`.
- `NOTES.md` updated with a pointer so affected machines can discover this script.

## Test plan
- [x] `bash scripts/check.sh` (shellcheck -x + bash -n) passes
- [x] Validated on a real machine that was actually in the exact pre-migration state: all 10 dangling symlinks removed, all 10 new `dfa-*` symlinks created correctly, aliases (`check`/`orphans`/`r`) confirmed working after `source ~/.bashrc`
- [x] Re-ran a second time to confirm idempotency — correctly reports "no dangling symlinks found" as a no-op
- [x] Two-axis code review (Standards + Spec) run against the accepted scope from conversation; the one real finding (no doc pointer for affected users) fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GoLvqeeaKm6oboUNPaHrxJ