### PR TITLE
fix(zed): clean up stray desktop entry from legacy manual install

### DIFF
--- a/scripts/setup-zed.sh
+++ b/scripts/setup-zed.sh
@@ -55,6 +55,27 @@ if [ -d "$LEGACY_ZED_APP_DIR" ] && [ -x "$LEGACY_ZED_APP_DIR/libexec/zed-editor"
     rm -rf "$LEGACY_ZED_APP_DIR"
 fi
 
+# The manual installer also dropped its own desktop entry into
+# ~/.local/share/applications, which — being a user data dir — takes
+# priority over the pacman package's /usr/share/applications entry of the
+# same ID. If Exec/TryExec/Icon in it point under $LEGACY_ZED_APP_DIR (now
+# removed above, or removed on a prior run), it's a dead entry: GNOME hides
+# it from the app grid (TryExec target missing) and its Icon path resolves
+# to nothing, showing a generic gear. Remove it so the system entry wins.
+LEGACY_ZED_DESKTOP_FILE="$USER_HOME_DIR/.local/share/applications/dev.zed.Zed.desktop"
+USER_APPLICATIONS_DIR="$USER_HOME_DIR/.local/share/applications"
+
+if [ -f "$LEGACY_ZED_DESKTOP_FILE" ] && grep -q "$LEGACY_ZED_APP_DIR" "$LEGACY_ZED_DESKTOP_FILE" 2>/dev/null; then
+    print_action_message "Removing stray Zed desktop entry: $LEGACY_ZED_DESKTOP_FILE (pointed at the removed manual install)"
+    rm -f "$LEGACY_ZED_DESKTOP_FILE"
+    if command -v update-desktop-database &>/dev/null; then
+        update-desktop-database "$USER_APPLICATIONS_DIR" &>/dev/null || true
+    fi
+    if command -v gtk-update-icon-cache &>/dev/null; then
+        gtk-update-icon-cache -qf "$USER_HOME_DIR/.local/share/icons/hicolor" &>/dev/null || true
+    fi
+fi
+
 # --------------------------
 # Install Zed via pacman
 # --------------------------


### PR DESCRIPTION
## Summary
- A manually-installed, self-updating Zed (`~/.local/zed.app`) from before the pacman package existed left behind a desktop entry at `~/.local/share/applications/dev.zed.Zed.desktop` pointing at its own now-removed binary/icon paths
- User-level desktop entries take priority over `/usr/share/applications`, so this dead entry shadows the pacman package's correct one — GNOME hides Zed from the app grid (TryExec target missing) and shows a generic gear icon (Icon path resolves to nothing)
- `setup-zed.sh` already cleaned up the stray app dir and `~/.local/bin/zed` shim but never removed this leftover launcher entry, so any machine that once had the manual install keeps hitting this on every bootstrap/sync
- Added cleanup: only removes the desktop file if it actually references the legacy app dir path, then refreshes the desktop database and icon cache

## Test plan
- [x] `shellcheck -x scripts/setup-zed.sh` passes
- [x] Verified on affected machine: confirmed `~/.local/zed.app` and its shim were already gone, but the stray desktop file at `~/.local/share/applications/dev.zed.Zed.desktop` still pointed at the removed paths; manually removed it and confirmed the pacman package's `/usr/share/applications/dev.zed.Zed.desktop` (correct icon, `Exec=zeditor`) now resolves
- [ ] Re-run `bash scripts/setup-zed.sh` (or `sync.sh`) on a machine with the leftover file to confirm the new cleanup block fires idempotently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014VW4Npv9hNKZqY88ZGH96Z