### PR TITLE
fix(code,nvim-reveal-edit): deepen tmux session-naming into a shared function

### DIFF
--- a/home/.local/bin/code
+++ b/home/.local/bin/code
@@ -109,12 +109,10 @@ if ! command -v nvim &>/dev/null; then
     exit 1
 fi
 
-# Generate a tmux-safe session name from the directory basename (no dots,
-# spaces, or colons); fall back to a hash if that leaves nothing usable.
-SESSION_NAME=$(basename "$TARGET_DIR" | tr '.' '_' | tr ' ' '_' | tr ':' '_')
-if [[ -z "$SESSION_NAME" || "$SESSION_NAME" =~ ^_+$ ]]; then
-    SESSION_NAME="dev_$(echo "$TARGET_DIR" | md5sum | cut -c1-8)"
-fi
+# Tmux-safe session name derived from the directory basename; see
+# tmux_session_name_for in dotfiles-arch-lib.sh (also used by nvim-reveal-edit
+# to find this session's Neovim socket).
+SESSION_NAME="$(tmux_session_name_for "$TARGET_DIR")"
 
 # Resolve the command to start in the agent pane, if any.
 agent_command() {

--- a/home/.local/bin/dotfiles-arch-lib.sh
+++ b/home/.local/bin/dotfiles-arch-lib.sh
@@ -74,3 +74,17 @@ list_git_repos_under() {
   local root_dir="$1"
   find "$root_dir" -mindepth 1 -maxdepth 3 -type d -name .git -prune -printf '%h\n' 2>/dev/null | sort -u
 }
+
+# Derive the tmux session name (and, by extension, the Neovim --listen socket
+# name) for a project directory: translate '.', ' ', ':' in the basename to
+# '_', falling back to a hash-based name when that leaves nothing usable.
+# Shared by `code` (session creation) and `nvim-reveal-edit` (socket lookup
+# during its upward directory walk) so the mapping can't silently diverge.
+tmux_session_name_for() {
+  local dir="$1" name
+  name="$(basename "$dir" | tr '.' '_' | tr ' ' '_' | tr ':' '_')"
+  if [[ -z "$name" || "$name" =~ ^_+$ ]]; then
+    name="dev_$(echo "$dir" | md5sum | cut -c1-8)"
+  fi
+  echo "$name"
+}

--- a/home/.local/bin/nvim-reveal-edit
+++ b/home/.local/bin/nvim-reveal-edit
@@ -18,6 +18,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/dotfiles-arch-lib.sh"
+
 command -v jq &>/dev/null || exit 0
 command -v nvim &>/dev/null || exit 0
 
@@ -28,12 +32,12 @@ FILE_PATH="$(jq -r '.file_path // .tool_input.file_path // .tool_input.notebook_
 
 FILE_PATH="$(realpath -m "$FILE_PATH")"
 
-# Walk up from the file looking for a live socket, matching the SESSION_NAME
-# derivation in home/.local/bin/code exactly (basename with '.', ' ', ':' -> '_').
+# Walk up from the file looking for a live socket, deriving each ancestor's
+# session name via the same tmux_session_name_for `code` uses to name it.
 SOCKET=""
 dir="$(dirname "$FILE_PATH")"
 while [[ -n "$dir" && "$dir" != "/" ]]; do
-  name="$(basename "$dir" | tr '.' '_' | tr ' ' '_' | tr ':' '_')"
+  name="$(tmux_session_name_for "$dir")"
   candidate="${XDG_RUNTIME_DIR:-/tmp}/dotfiles-arch-nvim-${name}.sock"
   if [[ -S "$candidate" ]]; then
     SOCKET="$candidate"


### PR DESCRIPTION
## Summary
- `code` and `nvim-reveal-edit` each derived the tmux/socket session name from a project directory's basename, kept in sync only by a source comment.
- `nvim-reveal-edit`'s copy reimplemented only the translate step and was missing the hash fallback entirely — any directory whose basename sanitizes to nothing usable (e.g. `...`) got a session/socket name from `code` that `nvim-reveal-edit` could never reconstruct, so reveal-on-edit silently failed for that project.
- Extracts `tmux_session_name_for(dir)` into `dotfiles-arch-lib.sh`; both `code` and `nvim-reveal-edit` now call it, so the mapping has exactly one implementation.

Closes #21

## Test plan
- [x] `bash scripts/check.sh` (`bash -n` + `shellcheck -x`) passes clean
- [x] Pure-function parity: `tmux_session_name_for` vs. the old inline logic across 7 cases (normal, dotted, spaced, colon, two all-symbol hash-fallback cases, mixed) — byte-identical
- [x] End-to-end with a real fake unix socket: confirmed `nvim-reveal-edit` now correctly locates the socket for a `...`-named directory (the bug fix)
- [x] End-to-end: normal-name case and no-live-socket silent-no-op path (exit 0, no output)
- [x] `/code-review` (Standards + Spec axes) run — 0 findings on both axes