### PR TITLE
refactor(setup-claude,setup-cursor): unify JSON hook-merge mechanic

### DIFF
--- a/scripts/fn-lib.sh
+++ b/scripts/fn-lib.sh
@@ -560,6 +560,43 @@ has_intel_gpu_hardware() {
 }
 
 # --------------------------
+# JSON config helpers
+# --------------------------
+
+# Idempotently merge a hook registration into a JSON config file via jq.
+# Args: file, seed_json (written if file doesn't exist), present_filter (a jq
+# -e boolean expression; a match means the hook is already registered, so
+# this is a no-op), merge_filter (a jq program producing the updated
+# document), label (human-readable description used in log messages).
+# Leaves the file untouched (with a warning) if jq is missing or the merge
+# filter fails against a malformed existing file.
+ensure_json_hook_registered() {
+  local file="$1" seed_json="$2" present_filter="$3" merge_filter="$4" label="$5"
+
+  if ! command -v jq &>/dev/null; then
+    print_warning_message "jq not found — skipping $label"
+    return
+  fi
+
+  mkdir -p "$(dirname "$file")"
+  [ -f "$file" ] || echo "$seed_json" > "$file"
+
+  if jq -e "$present_filter" "$file" &>/dev/null; then
+    return
+  fi
+
+  local tmp
+  tmp="$(mktemp)"
+  if jq "$merge_filter" "$file" > "$tmp"; then
+    mv "$tmp" "$file"
+    print_success_message "Added $label to $file"
+  else
+    rm -f "$tmp"
+    print_warning_message "Could not update $file — add $label manually"
+  fi
+}
+
+# --------------------------
 # Package helpers
 # --------------------------
 

--- a/scripts/setup-claude.sh
+++ b/scripts/setup-claude.sh
@@ -45,32 +45,9 @@ fi
 # are left alone.
 CLAUDE_SETTINGS_FILE="$USER_HOME_DIR/.claude/settings.json"
 
-ensure_claude_nvim_reveal_hook() {
-  if ! command -v jq &>/dev/null; then
-    print_warning_message "jq not found — skipping Neovim reveal-on-edit hook for Claude Code"
-    return
-  fi
-
-  mkdir -p "$(dirname "$CLAUDE_SETTINGS_FILE")"
-  [ -f "$CLAUDE_SETTINGS_FILE" ] || echo '{}' > "$CLAUDE_SETTINGS_FILE"
-
-  if jq -e '(.hooks.PostToolUse // []) | any(.hooks[]?.command == "nvim-reveal-edit")' \
-    "$CLAUDE_SETTINGS_FILE" &>/dev/null; then
-    return
-  fi
-
-  local tmp
-  tmp="$(mktemp)"
-  if jq '.hooks.PostToolUse = ((.hooks.PostToolUse // []) + [{"matcher": "Edit|Write|NotebookEdit", "hooks": [{"type": "command", "command": "nvim-reveal-edit", "timeout": 5}]}])' \
-    "$CLAUDE_SETTINGS_FILE" > "$tmp"; then
-    mv "$tmp" "$CLAUDE_SETTINGS_FILE"
-    print_success_message "Added Neovim reveal-on-edit hook to $CLAUDE_SETTINGS_FILE"
-  else
-    rm -f "$tmp"
-    print_warning_message "Could not update $CLAUDE_SETTINGS_FILE — add the PostToolUse hook manually"
-  fi
-}
-
-ensure_claude_nvim_reveal_hook
+ensure_json_hook_registered "$CLAUDE_SETTINGS_FILE" '{}' \
+  '(.hooks.PostToolUse // []) | any(.hooks[]?.command == "nvim-reveal-edit")' \
+  '.hooks.PostToolUse = ((.hooks.PostToolUse // []) + [{"matcher": "Edit|Write|NotebookEdit", "hooks": [{"type": "command", "command": "nvim-reveal-edit", "timeout": 5}]}])' \
+  "the Neovim reveal-on-edit PostToolUse hook"
 
 print_tool_setup_complete "Claude Code"

--- a/scripts/setup-cursor.sh
+++ b/scripts/setup-cursor.sh
@@ -235,33 +235,10 @@ fi
 # JSONC), so jq is safe to use directly here.
 CURSOR_HOOKS_FILE="$USER_HOME_DIR/.cursor/hooks.json"
 
-ensure_cursor_nvim_reveal_hook() {
-  if ! command -v jq &>/dev/null; then
-    print_warning_message "jq not found — skipping Neovim reveal-on-edit hook for Cursor Agent CLI"
-    return
-  fi
-
-  mkdir -p "$(dirname "$CURSOR_HOOKS_FILE")"
-  [ -f "$CURSOR_HOOKS_FILE" ] || echo '{"version": 1, "hooks": {}}' > "$CURSOR_HOOKS_FILE"
-
-  if jq -e '(.hooks.afterFileEdit // []) | any(.command == "nvim-reveal-edit")' \
-    "$CURSOR_HOOKS_FILE" &>/dev/null; then
-    return
-  fi
-
-  local tmp
-  tmp="$(mktemp)"
-  if jq '.version = (.version // 1) | .hooks.afterFileEdit = ((.hooks.afterFileEdit // []) + [{"command": "nvim-reveal-edit"}])' \
-    "$CURSOR_HOOKS_FILE" > "$tmp"; then
-    mv "$tmp" "$CURSOR_HOOKS_FILE"
-    print_success_message "Added Neovim reveal-on-edit hook to $CURSOR_HOOKS_FILE"
-  else
-    rm -f "$tmp"
-    print_warning_message "Could not update $CURSOR_HOOKS_FILE — add the afterFileEdit hook manually"
-  fi
-}
-
-ensure_cursor_nvim_reveal_hook
+ensure_json_hook_registered "$CURSOR_HOOKS_FILE" '{"version": 1, "hooks": {}}' \
+  '(.hooks.afterFileEdit // []) | any(.command == "nvim-reveal-edit")' \
+  '.version = (.version // 1) | .hooks.afterFileEdit = ((.hooks.afterFileEdit // []) + [{"command": "nvim-reveal-edit"}])' \
+  "the Neovim reveal-on-edit afterFileEdit hook"
 
 print_info_message "Settings are linked to ~/.config/Cursor/User/ via link-dotfiles.sh"
 print_tool_setup_complete "Cursor IDE"


### PR DESCRIPTION
## Summary
- `ensure_claude_nvim_reveal_hook` (`setup-claude.sh`) and `ensure_cursor_nvim_reveal_hook` (`setup-cursor.sh`) each hand-implemented an identical five-step jq mechanic (check jq, seed file, check-present, mktemp/merge/mv, warn-on-failure) to register the `nvim-reveal-edit` hook, differing only in file path, seed JSON, and jq filters.
- Extracts the mechanic into `ensure_json_hook_registered(file, seed_json, present_filter, merge_filter, label)` in `fn-lib.sh`; both setup scripts now pass their own file/seed/filters instead of duplicating the mechanics.
- All four jq filters and both seed JSON strings are verbatim cut-pastes from the originals, so the resulting `settings.json`/`hooks.json` content is unchanged; only console log wording is reworded to be generic across both call sites.

Closes #22

## Test plan
- [x] `bash scripts/check.sh` (`bash -n` + `shellcheck -x`) passes clean
- [x] Live fixture tests: seed-from-nothing, idempotent no-op (second call unchanged), unrelated-key preservation, malformed-JSON handling (warn, file untouched) — for both Claude and Cursor filter pairs
- [x] Missing-`jq` guard confirmed structurally unchanged from the original (byte-identical guard clause, just parameterized)
- [x] `/code-review` (Standards + Spec axes) run — 0 findings on both axes