### PR TITLE
refactor(bootstrap,sync): extract shared sudo-keepalive and setup-runner

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -89,6 +89,7 @@ if [ -n "$FORCE_PROFILE" ]; then
 elif ! SETUP_PROFILES="$(normalize_setup_profiles "$SETUP_PROFILES")"; then
   SETUP_PROFILES="work"
 fi
+# shellcheck disable=SC2034 # exported by run_profile_setup_scripts (fn-lib.sh)
 SETUP_PROFILE="$(primary_setup_profile)"
 
 if [ "$ASSUME_YES" = true ]; then
@@ -135,6 +136,7 @@ else
       exit 1
     fi
   fi
+  # shellcheck disable=SC2034 # exported by run_profile_setup_scripts (fn-lib.sh)
   SETUP_PROFILE="$(primary_setup_profile)"
 fi
 
@@ -169,15 +171,7 @@ print_info_message "User: $(whoami)  Home: $USER_HOME_DIR"
 print_info_message "Profiles: $(format_setup_profiles)  INSTALL_NVIDIA: $INSTALL_NVIDIA  MACHINE_TYPE: $MACHINE_TYPE"
 
 sudo -v
-{
-  while true; do
-    sudo -n true
-    sleep 60
-    kill -0 "$$" 2>/dev/null || exit
-  done
-} &
-SUDO_KEEPALIVE_PID=$!
-trap 'kill $SUDO_KEEPALIVE_PID 2>/dev/null' EXIT
+start_sudo_keepalive
 
 # --------------------------
 # Allow multilib in pacman
@@ -217,16 +211,7 @@ fi
 
 print_info_message "Running bootstrap with profiles: $(format_setup_profiles)"
 
-export SETUP_PROFILES SETUP_PROFILE FULL_NAME EMAIL_ADDRESS INSTALL_NVIDIA MACHINE_TYPE
-export SETUP_CONTINUE_ON_ERROR=true
-export DOTFILES_AUR_ASSUME_YES=true
-set +e
-bash "$DF_SCRIPT_DIR/run-profile-setup.sh"
-SETUP_RC=$?
-set -e
-if [ "$SETUP_RC" -ne 0 ]; then
-  print_warning_message "Some setup scripts failed (see above). Continuing with link/cleanup."
-fi
+run_profile_setup_scripts "true" || true
 
 bash "$DF_SCRIPT_DIR/link-dotfiles.sh" "$(format_setup_profiles)"
 bash "$DF_SCRIPT_DIR/post-link-hooks.sh"

--- a/scripts/fn-lib.sh
+++ b/scripts/fn-lib.sh
@@ -771,6 +771,52 @@ remove_orphaned_packages() {
 }
 
 # --------------------------
+# bootstrap.sh / sync.sh shared orchestration
+# --------------------------
+
+# Start a background sudo-refresh loop plus an EXIT trap to kill it. Does not
+# itself call `sudo -v` — callers decide whether/how to prime the sudo
+# timestamp first (bootstrap.sh always does; sync.sh guards it by SUDO_USER).
+start_sudo_keepalive() {
+  {
+    while true; do
+      sudo -n true
+      sleep 60
+      kill -0 "$$" 2>/dev/null || exit
+    done
+  } &
+  SUDO_KEEPALIVE_PID=$!
+  trap 'kill $SUDO_KEEPALIVE_PID 2>/dev/null' EXIT
+}
+
+# Export the shared setup-profile env vars, run run-profile-setup.sh under
+# DF_SCRIPT_DIR, and report (without aborting under `set -e`) if it failed.
+# assume_yes ("true"/"false") controls DOTFILES_AUR_ASSUME_YES: bootstrap.sh
+# always passes "true"; sync.sh passes its --yes-derived flag, unsetting the
+# var (not just leaving it false) to match its original interactive-prompt
+# behavior when not assumed.
+run_profile_setup_scripts() {
+  local assume_yes="${1:-false}" rc
+
+  export SETUP_PROFILES SETUP_PROFILE FULL_NAME EMAIL_ADDRESS INSTALL_NVIDIA MACHINE_TYPE
+  export SETUP_CONTINUE_ON_ERROR=true
+  if [[ "$assume_yes" == "true" ]]; then
+    export DOTFILES_AUR_ASSUME_YES=true
+  else
+    unset DOTFILES_AUR_ASSUME_YES 2>/dev/null || true
+  fi
+
+  set +e
+  bash "$DF_SCRIPT_DIR/run-profile-setup.sh"
+  rc=$?
+  set -e
+  if [[ "$rc" -ne 0 ]]; then
+    print_warning_message "Some setup scripts failed (see above). Continuing with link/cleanup."
+  fi
+  return "$rc"
+}
+
+# --------------------------
 # NVM / Node
 # --------------------------
 

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -160,6 +160,7 @@ else
   print_info_message "Using profiles: $(fmt_choice "$(format_setup_profiles "$SETUP_PROFILES")")"
 fi
 
+# shellcheck disable=SC2034 # exported by run_profile_setup_scripts (fn-lib.sh)
 SETUP_PROFILE="$(primary_setup_profile)"
 if ! validate_bootstrap_profile; then
   print_error_message "Profiles must be a non-empty subset of work|personal|devcontainer (got: ${SETUP_PROFILES:-})"
@@ -208,15 +209,7 @@ if [ "$(whoami)" = "${SUDO_USER:-$(whoami)}" ]; then
   sudo -v
 fi
 
-{
-  while true; do
-    sudo -n true
-    sleep 60
-    kill -0 "$$" 2>/dev/null || exit
-  done
-} &
-SUDO_KEEPALIVE_PID=$!
-trap 'kill $SUDO_KEEPALIVE_PID 2>/dev/null' EXIT
+start_sudo_keepalive
 
 ensure_yay_installed || print_warning_message "yay install failed — AUR steps may fail"
 
@@ -240,21 +233,7 @@ fi
 
 if [ "$SKIP_BOOTSTRAP" = false ]; then
   print_line_break "Running setup scripts (safe to re-run)"
-
-  export SETUP_PROFILES SETUP_PROFILE FULL_NAME EMAIL_ADDRESS INSTALL_NVIDIA MACHINE_TYPE
-  export SETUP_CONTINUE_ON_ERROR=true
-  if [ "$ASSUME_YES" = true ]; then
-    export DOTFILES_AUR_ASSUME_YES=true
-  else
-    unset DOTFILES_AUR_ASSUME_YES 2>/dev/null || true
-  fi
-  set +e
-  bash "$DF_SCRIPT_DIR/run-profile-setup.sh"
-  SETUP_RC=$?
-  set -e
-  if [ "$SETUP_RC" -ne 0 ]; then
-    print_warning_message "Some setup scripts failed (see above). Continuing with link/cleanup."
-  fi
+  run_profile_setup_scripts "$ASSUME_YES" || true
 else
   print_info_message "Skipping setup scripts (--skip-bootstrap)"
 fi


### PR DESCRIPTION
## Summary
- `bootstrap.sh` and `sync.sh` each inlined the same sudo-keepalive (background `sudo -n true` loop + `EXIT` trap) and export/run/capture-rc block around `run-profile-setup.sh`, with no shared interface — the two copies had already drifted (sync.sh guards `sudo -v` by `SUDO_USER`; bootstrap.sh doesn't; bootstrap.sh always assumed yes for AUR, sync.sh only when `--yes`).
- Extracts `start_sudo_keepalive()` and `run_profile_setup_scripts(assume_yes)` into `fn-lib.sh`.
- The `sudo -v` priming call stays in each caller unchanged, since it's the one deliberate behavioral difference between the two scripts.
- Callers now guard the call with `|| true` since the function returns `run-profile-setup.sh`'s exit code and both scripts run under `set -e`.

Closes #23

## Test plan
- [x] `bash scripts/check.sh` (`bash -n` + `shellcheck -x`) passes clean (required adding 3 narrowly-scoped `shellcheck disable=SC2034` comments — moving the `export ... SETUP_PROFILE` line into fn-lib.sh made shellcheck's per-file analysis lose track of a variable it can't trace through the dynamically-sourced file)
- [x] `start_sudo_keepalive`: verified directly — spawns a background PID, `EXIT` trap correctly kills it, no orphaned loop survives
- [x] `run_profile_setup_scripts`: verified against a fake `run-profile-setup.sh` in a scratch `DF_SCRIPT_DIR` — assume_yes=true/false export/unset behavior, exit-code propagation, warning-on-failure, and that `|| true` at the call site prevents `set -e` from aborting on a setup-script failure
- [x] Verified by reading: bootstrap's unconditional `sudo -v` and sync's `SUDO_USER`-guarded `sudo -v` are both unchanged in position/logic; `sync.sh --skip-bootstrap` still skips the call entirely while keepalive/upgrade still run; bootstrap's `run_profile_setup_scripts "true"` reproduces its old unconditional `DOTFILES_AUR_ASSUME_YES=true`
- [ ] **Not done**: a real end-to-end run of `bootstrap.sh`/`sync.sh` against a live system (would invoke real `sudo`/`pacman`/`yay`) — verification above is via isolated fixtures instead
- [x] `/code-review` (Standards + Spec axes) run — 0 hard violations on either axis; one judgement-call note (the blanket `|| true` swallows any nonzero return, not just an expected downstream failure — currently latent since nothing else in the function is fallible)