### PR TITLE
Add Voxtype dictation + merge-shorthand rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,7 @@ Shared: Kitty, tmux, Claude Code, Neovim, languages, Docker, Spotify, Obsidian, 
 ## Development notes
 
 - Scripts use bash; prefer `pacman -Q` for install checks
+- Favor official-repo (`pacman`) packages over AUR (`ensure_yay_pkgs`) whenever both provide the same package; reach for AUR only when there's no official-repo equivalent
 - Run `bash scripts/check.sh` (or `check`) after shell changes — `bash -n` + `shellcheck -x`
 - Config persistence: `~/.config/dotfiles-arch/`
 - Dotfiles link to `$USER_HOME_DIR`, not root’s home when run with sudo

--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -115,6 +115,7 @@ directly-installed packages are listed; transitive dependencies are not.
 | `postman-bin` (AUR) | `setup-postman.sh` | API client |
 | `spotify` (AUR) | `setup-spotify.sh` | Music |
 | `obsidian` (AUR) | `setup-obsidian.sh` | Notes |
+| `voxtype-bin` (AUR), `dotool` (AUR) | `setup-voxtype.sh` | Voice-to-text dictation — Super+T toggles |
 | `zed` | `setup-zed.sh` | Code editor |
 | `zsa-keymapp-bin` (AUR) | `setup-moonlander.sh` | ZSA Moonlander keyboard flashing |
 

--- a/rules/git-merge-shorthand.md
+++ b/rules/git-merge-shorthand.md
@@ -1,0 +1,21 @@
+---
+description: What "merge this" means as a shorthand for the full branch → PR → merge workflow
+alwaysApply: true
+---
+
+When I say "merge this" (or an equivalent like "ship this", "let's merge"), treat it as
+shorthand for the whole workflow, not a literal `git merge`:
+
+1. If the current branch is `main` (or otherwise not already a feature branch), create a
+   new branch first — never commit directly to `main`.
+2. Commit the pending changes.
+3. Push the branch to the remote.
+4. Open a pull request.
+5. Merge the pull request.
+
+After the merge, follow the usual cleanup: delete both the local and remote branch and
+check out `main`.
+
+Still confirm before any destructive or hard-to-reverse step (force-push, skipping hooks,
+etc.) per standard git safety practice — this shorthand covers *what* the request means,
+not a license to skip normal confirmation.

--- a/scripts/run-profile-setup.sh
+++ b/scripts/run-profile-setup.sh
@@ -88,6 +88,7 @@ run_setup setup-postman.sh
 run_setup setup-moonlander.sh
 run_setup setup-spotify.sh
 run_setup setup-obsidian.sh
+run_setup setup-voxtype.sh
 run_setup setup-zed.sh
 
 # Additive profile extras (multi-select — all selected profiles are installed)

--- a/scripts/setup-gnome.sh
+++ b/scripts/setup-gnome.sh
@@ -588,9 +588,23 @@ gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:$CU
 gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:$CUSTOM_KB_EMOJI command 'gnome-characters'
 gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:$CUSTOM_KB_EMOJI binding '<Super>period'
 
+# Super+T toggles Voxtype dictation (voxtype-bin, see setup-voxtype.sh).
+# GNOME/Wayland has no key-release shortcut event, so this drives voxtype's
+# toggle mode rather than true push-to-talk; voxtype's own hotkey is
+# disabled in its config so the two don't fight over the same key.
+CUSTOM_KB_VOXTYPE="/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom5/"
+if command -v voxtype &> /dev/null; then
+    gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:$CUSTOM_KB_VOXTYPE name 'Voxtype Toggle Dictation'
+    gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:$CUSTOM_KB_VOXTYPE command 'voxtype record toggle'
+    gsettings set org.gnome.settings-daemon.plugins.media-keys.custom-keybinding:$CUSTOM_KB_VOXTYPE binding '<Super>t'
+    VOXTYPE_CUSTOM_KEYBINDINGS=", '$CUSTOM_KB_VOXTYPE'"
+else
+    VOXTYPE_CUSTOM_KEYBINDINGS=""
+fi
+
 # Update the custom keybindings list (no empty custom0; Super+E uses built-in Home)
 gsettings set org.gnome.settings-daemon.plugins.media-keys custom-keybindings \
-  "['$CUSTOM_KB_TERMINAL', '$CUSTOM_KB_EMOJI', '$CUSTOM_KB_BROWSER', '$CUSTOM_KB_CLIPBOARD']"
+  "['$CUSTOM_KB_TERMINAL', '$CUSTOM_KB_EMOJI', '$CUSTOM_KB_BROWSER', '$CUSTOM_KB_CLIPBOARD'$VOXTYPE_CUSTOM_KEYBINDINGS]"
 
 # Screenshot UI (region/window/screen picker, includes copy to clipboard)
 gsettings set org.gnome.shell.keybindings show-screenshot-ui "['<Super><Shift>s', 'Print']"
@@ -640,6 +654,7 @@ print_info_message "  - File Explorer: Super+E"
 print_info_message "  - Browser: Super+B"
 print_info_message "  - Clipboard history (GPaste): Super+V"
 print_info_message "  - Emoji picker: Super+."
+print_info_message "  - Voxtype dictation toggle: Super+T"
 print_info_message "  - Screenshot UI: Super+Shift+S (or Print)"
 print_info_message ""
 print_warning_message "Log out and back in so GNOME reloads extensions (Dash to Panel, GPaste, AppIndicator, Pop Shell)."

--- a/scripts/setup-voxtype.sh
+++ b/scripts/setup-voxtype.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+
+# --------------------------
+# Setup Voxtype for Arch Linux
+# --------------------------
+# Voxtype (https://voxtype.io) is a push-to-talk / toggle voice-to-text
+# daemon. Omarchy (basecamp/omarchy) ships it on Hyprland, where the
+# compositor supports both the virtual-keyboard protocol (wtype output) and
+# key-release events (true push-to-talk, e.g. hold F9). GNOME/Wayland has
+# neither: no virtual-keyboard-protocol support (wtype fails, so we install
+# dotool instead) and no key-release shortcut event, so we drive voxtype's
+# toggle mode from a GNOME custom keybinding (see setup-gnome.sh, Super+T)
+# instead of voxtype's own evdev-level hotkey.
+# --------------------------
+
+# --------------------------
+# Import Common Header
+# --------------------------
+
+CURRENT_FILE_DIR="$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)"
+
+if [ -r "$CURRENT_FILE_DIR/dotheader.sh" ]; then
+  # shellcheck source=/dev/null
+  source "$CURRENT_FILE_DIR/dotheader.sh"
+else
+  echo "Missing header file: $CURRENT_FILE_DIR/dotheader.sh"
+  exit 1
+fi
+
+# --------------------------
+# End Import Common Header
+# --------------------------
+
+print_tool_setup_start "Voxtype"
+
+# --------------------------
+# Install voxtype + dotool (AUR — no official-repo equivalent exists)
+# --------------------------
+
+if command -v voxtype &> /dev/null; then
+    print_info_message "Voxtype is already installed. Skipping installation."
+else
+    print_info_message "Installing Voxtype from AUR (voxtype-bin)"
+    ensure_yay_pkgs voxtype-bin
+fi
+
+# dotool types on GNOME/KDE Wayland, where voxtype's default wtype output
+# driver isn't supported (no virtual-keyboard-protocol support).
+if ! command -v dotool &> /dev/null; then
+    print_info_message "Installing dotool from AUR (Wayland text-injection fallback for GNOME)"
+    ensure_yay_pkgs dotool
+fi
+
+if ! command -v voxtype &> /dev/null; then
+    print_error_message "Voxtype installation failed"
+    print_info_message "You can manually install with: yay -S voxtype-bin (review PKGBUILD first)"
+    print_tool_setup_complete "Voxtype"
+    exit 0
+fi
+
+# --------------------------
+# Config: disable voxtype's own hotkey, drive it via GNOME's Super+T instead
+# --------------------------
+
+VOXTYPE_CONFIG_DIR="$USER_HOME_DIR/.config/voxtype"
+VOXTYPE_CONFIG_FILE="$VOXTYPE_CONFIG_DIR/config.toml"
+
+if [ ! -f "$VOXTYPE_CONFIG_FILE" ]; then
+    print_info_message "Writing default Voxtype config ($VOXTYPE_CONFIG_FILE)"
+    mkdir -p "$VOXTYPE_CONFIG_DIR"
+    cat > "$VOXTYPE_CONFIG_FILE" <<'EOF'
+# Managed by dotfiles-arch (scripts/setup-voxtype.sh).
+# Toggled via GNOME's Super+T custom keybinding (scripts/setup-gnome.sh),
+# not voxtype's own evdev hotkey — GNOME/Wayland offers no key-release
+# event for true push-to-talk.
+[hotkey]
+enabled = false
+
+[output]
+mode = "type"
+driver_order = ["dotool", "clipboard"]
+EOF
+elif ! grep -q '^\[hotkey\]' "$VOXTYPE_CONFIG_FILE" 2>/dev/null; then
+    print_warning_message "Existing $VOXTYPE_CONFIG_FILE has no [hotkey] section — leaving it as-is"
+    print_info_message "Add 'enabled = false' under [hotkey] so it doesn't fight the Super+T toggle binding"
+fi
+
+if [ -n "${SUDO_USER-}" ]; then
+    sudo chown -R "$SUDO_USER" "$VOXTYPE_CONFIG_DIR"
+fi
+
+# --------------------------
+# Download the default speech model (idempotent)
+# --------------------------
+
+print_info_message "Ensuring the default Voxtype speech model is downloaded"
+voxtype setup --download --no-post-install || print_warning_message "voxtype setup --download failed — run it manually to fetch the speech model"
+
+# GPU-accelerate transcription when a Vulkan ICD is present (any vendor).
+if [[ -d /usr/share/vulkan/icd.d ]] && find /usr/share/vulkan/icd.d -maxdepth 1 -name "*.json" -print -quit 2>/dev/null | grep -q .; then
+    print_info_message "Vulkan detected — enabling GPU transcription"
+    voxtype setup gpu --enable || print_warning_message "voxtype setup gpu --enable failed — transcription will stay on CPU"
+fi
+
+# --------------------------
+# Enable the systemd --user service
+# --------------------------
+
+voxtype setup systemd || print_warning_message "voxtype setup systemd failed — start the daemon manually with: voxtype"
+
+print_info_message "Toggle dictation with Super+T (configured in setup-gnome.sh)"
+
+print_tool_setup_complete "Voxtype"


### PR DESCRIPTION
## Summary
- Adds `scripts/setup-voxtype.sh`: installs `voxtype-bin` + `dotool` (AUR) on every profile, configures Voxtype for GNOME (toggle mode, GPU accel if Vulkan present, systemd user service), wired into `run-profile-setup.sh`.
- `scripts/setup-gnome.sh`: binds Super+T to `voxtype record toggle` via a GNOME custom keybinding — GNOME/Wayland has no key-release shortcut event, so this drives toggle mode rather than true push-to-talk; implementation cross-checked against how Omarchy (basecamp/omarchy) wires up Voxtype on Hyprland.
- `PACKAGES.md`: documents the new packages and shortcut.
- `CLAUDE.md`: adds a standing preference for pacman over AUR when both provide the same package.
- `rules/git-merge-shorthand.md`: personal always-on rule defining "merge this" as branch → commit → push → PR → merge → cleanup, synced to `~/.claude/CLAUDE.md` and `~/.cursor/rules/`.

## Test plan
- [x] `bash scripts/check.sh` (`bash -n` + `shellcheck -x`) passes
- [ ] Run `bash scripts/setup-voxtype.sh` on a real machine and confirm Super+T toggles dictation after a GNOME logout/login

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQtTgcd6FD4VHA1v3R8vWK