### PR TITLE
feat(fn-lib): add symmetric uninstall helpers

### DIFF
--- a/scripts/fn-lib.sh
+++ b/scripts/fn-lib.sh
@@ -618,6 +618,25 @@ ensure_pacman_pkgs() {
   sudo pacman -S --needed --noconfirm "${missing[@]}"
 }
 
+# Remove installed pacman packages (idempotent). Usage: remove_pacman_pkgs pkg1 pkg2 ...
+# No-op (and no error) for any package that's already absent.
+remove_pacman_pkgs() {
+  local pkg
+  local present=()
+  for pkg in "$@"; do
+    if pacman -Q "$pkg" &>/dev/null; then
+      present+=("$pkg")
+    else
+      print_info_message "Already absent: $pkg"
+    fi
+  done
+  if [[ ${#present[@]} -eq 0 ]]; then
+    return 0
+  fi
+  print_action_message "Removing via pacman: ${present[*]}"
+  sudo pacman -Rns --noconfirm "${present[@]}"
+}
+
 # Ensure [multilib] (and its Include) are uncommented in pacman.conf.
 # Sets MULTILIB_CHANGED=true when the file was modified; false otherwise.
 ensure_multilib_enabled() {
@@ -712,6 +731,15 @@ ensure_yay_pkgs() {
     print_info_message "IoC scan clean. Running interactive yay (review PKGBUILD if prompted)."
     yay -S --needed "${missing[@]}"
   fi
+}
+
+# Remove installed AUR packages (idempotent). Usage: remove_yay_pkgs pkg1 pkg2 ...
+# AUR packages are removed the same way official ones are — `pacman -R`, not
+# `yay -R` (yay has no removal mode beyond what pacman already does) — so this
+# is a thin, semantically-named wrapper kept alongside remove_pacman_pkgs to
+# mirror ensure_yay_pkgs's existence next to ensure_pacman_pkgs.
+remove_yay_pkgs() {
+  remove_pacman_pkgs "$@"
 }
 
 # Guarded full system update: pacman -Syu + AUR scan + yay -Syu.

--- a/scripts/setup-docker.sh
+++ b/scripts/setup-docker.sh
@@ -56,17 +56,7 @@ fi
 # --------------------------
 
 # Uninstall old incompatible packages if they exist
-OLD_PACKAGES=()
-for pkg in docker-compose podman podman-docker; do
-  if pacman -Q "$pkg" &> /dev/null; then
-    OLD_PACKAGES+=("$pkg")
-  fi
-done
-
-if [ ${#OLD_PACKAGES[@]} -gt 0 ]; then
-  print_info_message "Removing old/conflicting packages: ${OLD_PACKAGES[*]}"
-  sudo pacman -R --noconfirm "${OLD_PACKAGES[@]}"
-fi
+remove_pacman_pkgs docker-compose podman podman-docker
 
 # --------------------------
 # Install Docker Packages


### PR DESCRIPTION
## Summary
- Adds `remove_pacman_pkgs`/`remove_yay_pkgs` to `scripts/fn-lib.sh`, mirroring `ensure_pacman_pkgs`/`ensure_yay_pkgs`'s idempotent conventions.
- Updates `scripts/setup-docker.sh` to use `remove_pacman_pkgs` for its old/conflicting-package removal, as proof of usage.

Closes #36

## Test plan
- [x] `bash scripts/check.sh` (bash -n + shellcheck) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151iieyNBPhYJwADzZ2CDBh