### PR TITLE
Set Zed CLI default open behavior to existing window

### DIFF
--- a/config/zed/settings.json
+++ b/config/zed/settings.json
@@ -7,6 +7,7 @@
 // custom settings, run `zed: open default settings` from the
 // command palette (cmd-shift-p / ctrl-shift-p)
 {
+  "cli_default_open_behavior": "existing_window",
   "agent_servers": {
     "cursor": {
       "type": "registry"


### PR DESCRIPTION
## Summary
- Adds `cli_default_open_behavior: "existing_window"` to `config/zed/settings.json` so invoking the `zed`/`zeditor` CLI reuses the current window instead of opening a new one.

## Test plan
- [ ] Re-link dotfiles and confirm `zed <path>` opens in the existing Zed window rather than spawning a new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151iieyNBPhYJwADzZ2CDBh