### PR TITLE
feat(dfa): Catalog Engine + manifest schema, proven with Essentials

### DIFF
--- a/dfa/catalog/items/bat.toml
+++ b/dfa/catalog/items/bat.toml
@@ -1,0 +1,12 @@
+id = "bat"
+name = "bat"
+description = "Syntax-highlighted `cat`/pager replacement."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["bat"]
+aur = []

--- a/dfa/catalog/items/btop.toml
+++ b/dfa/catalog/items/btop.toml
@@ -1,0 +1,12 @@
+id = "btop"
+name = "btop"
+description = "Richer, graphical resource monitor."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["btop"]
+aur = []

--- a/dfa/catalog/items/curl.toml
+++ b/dfa/catalog/items/curl.toml
@@ -1,0 +1,12 @@
+id = "curl"
+name = "curl"
+description = "Command-line HTTP/file transfer client."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["curl"]
+aur = []

--- a/dfa/catalog/items/duf.toml
+++ b/dfa/catalog/items/duf.toml
@@ -1,0 +1,12 @@
+id = "duf"
+name = "duf"
+description = "Friendly, colorized `df` replacement."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["duf"]
+aur = []

--- a/dfa/catalog/items/eza.toml
+++ b/dfa/catalog/items/eza.toml
@@ -1,0 +1,12 @@
+id = "eza"
+name = "eza"
+description = "Modern `ls` replacement with icons and git status."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["eza"]
+aur = []

--- a/dfa/catalog/items/fastfetch.toml
+++ b/dfa/catalog/items/fastfetch.toml
@@ -1,0 +1,12 @@
+id = "fastfetch"
+name = "fastfetch"
+description = "Fast system information summary."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["fastfetch"]
+aur = []

--- a/dfa/catalog/items/fd.toml
+++ b/dfa/catalog/items/fd.toml
@@ -1,0 +1,12 @@
+id = "fd"
+name = "fd"
+description = "Fast, user-friendly `find` replacement."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["fd"]
+aur = []

--- a/dfa/catalog/items/fzf.toml
+++ b/dfa/catalog/items/fzf.toml
@@ -1,0 +1,12 @@
+id = "fzf"
+name = "fzf"
+description = "Command-line fuzzy finder for files and history."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["fzf"]
+aur = []

--- a/dfa/catalog/items/git-delta.toml
+++ b/dfa/catalog/items/git-delta.toml
@@ -1,0 +1,12 @@
+id = "git-delta"
+name = "git-delta"
+description = "Syntax-highlighted, side-by-side git diffs."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["git-delta"]
+aur = []

--- a/dfa/catalog/items/git.toml
+++ b/dfa/catalog/items/git.toml
@@ -1,0 +1,12 @@
+id = "git"
+name = "git"
+description = "Distributed version control."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["git"]
+aur = []

--- a/dfa/catalog/items/github-cli.toml
+++ b/dfa/catalog/items/github-cli.toml
@@ -1,0 +1,12 @@
+id = "github-cli"
+name = "github-cli"
+description = "GitHub from the terminal (`gh`); also the git credential helper."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["github-cli"]
+aur = []

--- a/dfa/catalog/items/glow.toml
+++ b/dfa/catalog/items/glow.toml
@@ -1,0 +1,12 @@
+id = "glow"
+name = "glow"
+description = "Terminal Markdown renderer."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["glow"]
+aur = []

--- a/dfa/catalog/items/htop.toml
+++ b/dfa/catalog/items/htop.toml
@@ -1,0 +1,12 @@
+id = "htop"
+name = "htop"
+description = "Interactive process viewer."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["htop"]
+aur = []

--- a/dfa/catalog/items/iw.toml
+++ b/dfa/catalog/items/iw.toml
@@ -1,0 +1,12 @@
+id = "iw"
+name = "iw"
+description = "Wireless device configuration and query (nl80211)."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["iw"]
+aur = []

--- a/dfa/catalog/items/jq.toml
+++ b/dfa/catalog/items/jq.toml
@@ -1,0 +1,12 @@
+id = "jq"
+name = "jq"
+description = "Command-line JSON processor."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["jq"]
+aur = []

--- a/dfa/catalog/items/ncdu.toml
+++ b/dfa/catalog/items/ncdu.toml
@@ -1,0 +1,12 @@
+id = "ncdu"
+name = "ncdu"
+description = "Interactive disk usage explorer."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["ncdu"]
+aur = []

--- a/dfa/catalog/items/net-tools.toml
+++ b/dfa/catalog/items/net-tools.toml
@@ -1,0 +1,12 @@
+id = "net-tools"
+name = "net-tools"
+description = "Legacy network utilities (ifconfig, netstat)."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["net-tools"]
+aur = []

--- a/dfa/catalog/items/ripgrep.toml
+++ b/dfa/catalog/items/ripgrep.toml
@@ -1,0 +1,12 @@
+id = "ripgrep"
+name = "ripgrep"
+description = "Fast recursive text search (`rg`)."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["ripgrep"]
+aur = []

--- a/dfa/catalog/items/shellcheck.toml
+++ b/dfa/catalog/items/shellcheck.toml
@@ -1,0 +1,12 @@
+id = "shellcheck"
+name = "shellcheck"
+description = "Static analysis for shell scripts."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["shellcheck"]
+aur = []

--- a/dfa/catalog/items/starship.toml
+++ b/dfa/catalog/items/starship.toml
@@ -1,0 +1,12 @@
+id = "starship"
+name = "starship"
+description = "Fast, customizable cross-shell prompt."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["starship"]
+aur = []

--- a/dfa/catalog/items/stow.toml
+++ b/dfa/catalog/items/stow.toml
@@ -1,0 +1,12 @@
+id = "stow"
+name = "stow"
+description = "Symlink farm manager for manual dotfile experiments."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["stow"]
+aur = []

--- a/dfa/catalog/items/tldr.toml
+++ b/dfa/catalog/items/tldr.toml
@@ -1,0 +1,12 @@
+id = "tldr"
+name = "tldr"
+description = "Example-first, community-maintained man pages."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["tldr"]
+aur = []

--- a/dfa/catalog/items/tree.toml
+++ b/dfa/catalog/items/tree.toml
@@ -1,0 +1,12 @@
+id = "tree"
+name = "tree"
+description = "Recursive directory listing as a tree."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["tree"]
+aur = []

--- a/dfa/catalog/items/wget.toml
+++ b/dfa/catalog/items/wget.toml
@@ -1,0 +1,12 @@
+id = "wget"
+name = "wget"
+description = "Command-line file downloader."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["wget"]
+aur = []

--- a/dfa/catalog/items/wl-clipboard.toml
+++ b/dfa/catalog/items/wl-clipboard.toml
@@ -1,0 +1,12 @@
+id = "wl-clipboard"
+name = "wl-clipboard"
+description = "Wayland clipboard copy/paste utilities."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["wl-clipboard"]
+aur = []

--- a/dfa/catalog/items/xsel.toml
+++ b/dfa/catalog/items/xsel.toml
@@ -1,0 +1,12 @@
+id = "xsel"
+name = "xsel"
+description = "X11 clipboard access for XWayland apps."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["xsel"]
+aur = []

--- a/dfa/catalog/items/zoxide.toml
+++ b/dfa/catalog/items/zoxide.toml
@@ -1,0 +1,12 @@
+id = "zoxide"
+name = "zoxide"
+description = "Directory jumping that learns your habits (`z`)."
+categories = ["essentials"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["zoxide"]
+aur = []

--- a/dfa/go.mod
+++ b/dfa/go.mod
@@ -3,6 +3,7 @@ module github.com/mikedelafuente/dotfiles-arch/dfa
 go 1.27.0
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/dfa/go.sum
+++ b/dfa/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=

--- a/dfa/internal/catalog/catalog.go
+++ b/dfa/internal/catalog/catalog.go
@@ -1,0 +1,349 @@
+// Package catalog is the pure Catalog Engine: given a Manifest (plain Go
+// data, no filesystem/exec/network) and a Selection, it computes dependency
+// resolution, cascade-deselection, Core-item uninstall refusal, and
+// install/uninstall plans. Loading manifests from disk lives in a separate
+// package (dfa/internal/catalogfs) so this one stays testable with in-memory
+// fixtures alone.
+package catalog
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
+
+// Tier distinguishes baseline Software Items (always selected, locked
+// against uninstall) from Optional ones the user freely toggles.
+type Tier string
+
+const (
+	TierCore     Tier = "core"
+	TierOptional Tier = "optional"
+)
+
+// Packages lists the backing packages a Software Item installs, split by
+// the package manager that provides them.
+type Packages struct {
+	Pacman []string
+	AUR    []string
+}
+
+// Item is one Software Item: a single declarative manifest entry.
+type Item struct {
+	ID           string
+	Name         string
+	Description  string
+	Categories   []string
+	Tier         Tier
+	Capabilities []string
+	Dependencies []string
+	Packages     Packages
+	SetupScript  string
+}
+
+// Manifest is the full, validated set of Software Items.
+type Manifest struct {
+	items   []Item
+	byID    map[string]Item
+	byOrder []string // ids in declaration order, for stable output
+}
+
+// NewManifest validates items (unique ids, dependencies/tiers referencing
+// real items and valid values) and returns a Manifest ready for use with
+// the rest of this package.
+func NewManifest(items []Item) (Manifest, error) {
+	byID := make(map[string]Item, len(items))
+	order := make([]string, 0, len(items))
+
+	for _, it := range items {
+		if it.ID == "" {
+			return Manifest{}, errors.New("catalog: item has empty id")
+		}
+		if _, exists := byID[it.ID]; exists {
+			return Manifest{}, fmt.Errorf("catalog: duplicate item id %q", it.ID)
+		}
+		if it.Tier != TierCore && it.Tier != TierOptional {
+			return Manifest{}, fmt.Errorf("catalog: item %q has invalid tier %q", it.ID, it.Tier)
+		}
+		byID[it.ID] = it
+		order = append(order, it.ID)
+	}
+
+	for _, it := range items {
+		for _, dep := range it.Dependencies {
+			if _, ok := byID[dep]; !ok {
+				return Manifest{}, fmt.Errorf("catalog: item %q depends on unknown item %q", it.ID, dep)
+			}
+		}
+	}
+
+	return Manifest{items: items, byID: byID, byOrder: order}, nil
+}
+
+// Item looks up a Software Item by id.
+func (m Manifest) Item(id string) (Item, bool) {
+	it, ok := m.byID[id]
+	return it, ok
+}
+
+// ItemsByCategory returns every item (in manifest declaration order) that
+// lists the given category.
+func (m Manifest) ItemsByCategory(category string) []Item {
+	var out []Item
+	for _, id := range m.byOrder {
+		it := m.byID[id]
+		for _, c := range it.Categories {
+			if c == category {
+				out = append(out, it)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// dependents returns the ids of every item that directly depends on id.
+func (m Manifest) dependents(id string) []string {
+	var out []string
+	for _, oid := range m.byOrder {
+		it := m.byID[oid]
+		for _, dep := range it.Dependencies {
+			if dep == id {
+				out = append(out, oid)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// Selection is the set of currently-selected item ids.
+type Selection map[string]bool
+
+// Clone returns an independent copy of the selection.
+func (s Selection) Clone() Selection {
+	out := make(Selection, len(s))
+	for k, v := range s {
+		out[k] = v
+	}
+	return out
+}
+
+// ErrUnknownItem is returned when an action names an id the manifest does
+// not have.
+var ErrUnknownItem = errors.New("catalog: unknown item id")
+
+// ErrCoreItemUninstall is returned when a requested change would remove a
+// Core item. The Catalog Engine refuses such plans outright.
+var ErrCoreItemUninstall = errors.New("catalog: cannot uninstall a core item")
+
+// Plan is the result of applying a selection change: the resulting
+// selection, plus the concrete install/uninstall work and any side effects
+// (auto-selected dependencies, cascade-deselected dependents) that
+// produced it.
+type Plan struct {
+	Selection         Selection
+	ToInstall         []string
+	ToUninstall       []string
+	AutoSelected      []string
+	CascadeDeselected []string
+	// CoreItemsSkipped lists Core items a DeselectCategory call left
+	// selected rather than refusing the whole plan over, so callers can
+	// surface why not everything in the category came out.
+	CoreItemsSkipped []string
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Diff computes the install/uninstall plan needed to move from current to
+// desired, with no dependency resolution of its own — callers that already
+// have a validated desired Selection (e.g. from Select/Deselect below) use
+// this to get the concrete plan.
+func Diff(current, desired Selection) Plan {
+	toInstall := map[string]bool{}
+	toUninstall := map[string]bool{}
+
+	for id, selected := range desired {
+		if selected && !current[id] {
+			toInstall[id] = true
+		}
+	}
+	for id, selected := range current {
+		if selected && !desired[id] {
+			toUninstall[id] = true
+		}
+	}
+
+	return Plan{
+		Selection:   desired.Clone(),
+		ToInstall:   sortedKeys(toInstall),
+		ToUninstall: sortedKeys(toUninstall),
+	}
+}
+
+// Select adds itemID to the selection, transitively auto-selecting any
+// declared dependencies that aren't already selected.
+func Select(manifest Manifest, current Selection, itemID string) (Plan, error) {
+	if _, ok := manifest.Item(itemID); !ok {
+		return Plan{}, fmt.Errorf("%w: %s", ErrUnknownItem, itemID)
+	}
+
+	desired := current.Clone()
+	var autoSelected []string
+
+	var visit func(id string, isRoot bool)
+	visit = func(id string, isRoot bool) {
+		alreadySelected := desired[id]
+		desired[id] = true
+		if !alreadySelected && !isRoot {
+			autoSelected = append(autoSelected, id)
+		}
+		it := manifest.byID[id]
+		for _, dep := range it.Dependencies {
+			visit(dep, false)
+		}
+	}
+	visit(itemID, true)
+
+	plan := Diff(current, desired)
+	plan.AutoSelected = autoSelected
+	return plan, nil
+}
+
+// Deselect removes itemID from the selection, cascading to any currently
+// selected items that transitively depend on it. It refuses (returning
+// ErrCoreItemUninstall) if itemID — or any item the cascade would also
+// remove — is a Core item.
+func Deselect(manifest Manifest, current Selection, itemID string) (Plan, error) {
+	it, ok := manifest.Item(itemID)
+	if !ok {
+		return Plan{}, fmt.Errorf("%w: %s", ErrUnknownItem, itemID)
+	}
+	if it.Tier == TierCore {
+		return Plan{}, fmt.Errorf("%w: %s", ErrCoreItemUninstall, itemID)
+	}
+
+	desired := current.Clone()
+	var cascade []string
+
+	var visit func(id string, isRoot bool) error
+	visit = func(id string, isRoot bool) error {
+		if !desired[id] {
+			return nil
+		}
+		cur := manifest.byID[id]
+		if cur.Tier == TierCore {
+			return fmt.Errorf("%w: %s", ErrCoreItemUninstall, id)
+		}
+		desired[id] = false
+		if !isRoot {
+			cascade = append(cascade, id)
+		}
+		for _, depID := range manifest.dependents(id) {
+			if err := visit(depID, false); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := visit(itemID, true); err != nil {
+		return Plan{}, err
+	}
+
+	plan := Diff(current, desired)
+	plan.CascadeDeselected = cascade
+	return plan, nil
+}
+
+// SelectCategory selects every item in the given category (plus their
+// transitive dependencies).
+func SelectCategory(manifest Manifest, current Selection, category string) (Plan, error) {
+	desired := current.Clone()
+	var autoSelected []string
+	seen := map[string]bool{}
+
+	var visit func(id string, isRoot bool)
+	visit = func(id string, isRoot bool) {
+		alreadySelected := desired[id]
+		desired[id] = true
+		if !alreadySelected && !isRoot && !seen[id] {
+			autoSelected = append(autoSelected, id)
+			seen[id] = true
+		}
+		it := manifest.byID[id]
+		for _, dep := range it.Dependencies {
+			visit(dep, false)
+		}
+	}
+
+	items := manifest.ItemsByCategory(category)
+	if len(items) == 0 {
+		return Plan{}, fmt.Errorf("catalog: unknown category %q", category)
+	}
+	for _, it := range items {
+		visit(it.ID, true)
+	}
+
+	plan := Diff(current, desired)
+	plan.AutoSelected = autoSelected
+	return plan, nil
+}
+
+// DeselectCategory deselects every non-Core item in the given category
+// (cascading to their dependents, same as Deselect), leaving any Core item
+// in the category untouched rather than erroring.
+func DeselectCategory(manifest Manifest, current Selection, category string) (Plan, error) {
+	items := manifest.ItemsByCategory(category)
+	if len(items) == 0 {
+		return Plan{}, fmt.Errorf("catalog: unknown category %q", category)
+	}
+
+	desired := current.Clone()
+	var cascade []string
+	var coreSkipped []string
+	seen := map[string]bool{}
+
+	var visit func(id string, isRoot bool) error
+	visit = func(id string, isRoot bool) error {
+		if !desired[id] {
+			return nil
+		}
+		cur := manifest.byID[id]
+		if cur.Tier == TierCore {
+			if isRoot {
+				coreSkipped = append(coreSkipped, id)
+				return nil // leave Core items alone rather than erroring
+			}
+			return fmt.Errorf("%w: %s", ErrCoreItemUninstall, id)
+		}
+		desired[id] = false
+		if !isRoot && !seen[id] {
+			cascade = append(cascade, id)
+			seen[id] = true
+		}
+		for _, depID := range manifest.dependents(id) {
+			if err := visit(depID, false); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	for _, it := range items {
+		if err := visit(it.ID, true); err != nil {
+			return Plan{}, err
+		}
+	}
+
+	plan := Diff(current, desired)
+	plan.CascadeDeselected = cascade
+	plan.CoreItemsSkipped = coreSkipped
+	return plan, nil
+}

--- a/dfa/internal/catalog/catalog_test.go
+++ b/dfa/internal/catalog/catalog_test.go
@@ -1,0 +1,220 @@
+package catalog
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func fixtureManifest(t *testing.T) Manifest {
+	t.Helper()
+	m, err := NewManifest([]Item{
+		{ID: "git", Name: "git", Description: "Version control", Categories: []string{"essentials"}, Tier: TierCore},
+		{ID: "git-delta", Name: "git-delta", Description: "Better git diffs", Categories: []string{"essentials"}, Tier: TierOptional, Dependencies: []string{"git"}},
+		{ID: "lazygit", Name: "lazygit", Description: "Git TUI built on git-delta", Categories: []string{"essentials"}, Tier: TierOptional, Dependencies: []string{"git-delta"}},
+		{ID: "starship", Name: "starship", Description: "Shell prompt", Categories: []string{"essentials"}, Tier: TierOptional},
+		{ID: "nvidia", Name: "nvidia", Description: "NVIDIA driver", Categories: []string{"hardware"}, Tier: TierOptional, Capabilities: []string{"nvidia-gpu"}},
+	})
+	if err != nil {
+		t.Fatalf("NewManifest() error = %v", err)
+	}
+	return m
+}
+
+func TestNewManifest_RejectsDuplicateID(t *testing.T) {
+	_, err := NewManifest([]Item{
+		{ID: "git", Tier: TierCore},
+		{ID: "git", Tier: TierCore},
+	})
+	if err == nil {
+		t.Fatal("expected error for duplicate id, got nil")
+	}
+}
+
+func TestNewManifest_RejectsUnknownDependency(t *testing.T) {
+	_, err := NewManifest([]Item{
+		{ID: "git-delta", Tier: TierOptional, Dependencies: []string{"git"}},
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown dependency, got nil")
+	}
+}
+
+func TestNewManifest_RejectsInvalidTier(t *testing.T) {
+	_, err := NewManifest([]Item{
+		{ID: "git", Tier: "bogus"},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid tier, got nil")
+	}
+}
+
+func TestSelect_AutoSelectsDependency(t *testing.T) {
+	m := fixtureManifest(t)
+	current := Selection{"git": true}
+
+	plan, err := Select(m, current, "git-delta")
+	if err != nil {
+		t.Fatalf("Select() error = %v", err)
+	}
+
+	if !plan.Selection["git-delta"] || !plan.Selection["git"] {
+		t.Errorf("Selection = %v, want git-delta and git selected", plan.Selection)
+	}
+	if want := []string{"git-delta"}; !reflect.DeepEqual(plan.ToInstall, want) {
+		t.Errorf("ToInstall = %v, want %v", plan.ToInstall, want)
+	}
+	if plan.AutoSelected != nil {
+		t.Errorf("AutoSelected = %v, want nil (git was already selected)", plan.AutoSelected)
+	}
+}
+
+func TestSelect_AutoSelectsMissingDependencyAndReportsIt(t *testing.T) {
+	m := fixtureManifest(t)
+	current := Selection{}
+
+	plan, err := Select(m, current, "git-delta")
+	if err != nil {
+		t.Fatalf("Select() error = %v", err)
+	}
+
+	if !plan.Selection["git"] {
+		t.Errorf("Selection = %v, want git auto-selected", plan.Selection)
+	}
+	if want := []string{"git"}; !reflect.DeepEqual(plan.AutoSelected, want) {
+		t.Errorf("AutoSelected = %v, want %v", plan.AutoSelected, want)
+	}
+	wantInstall := []string{"git", "git-delta"}
+	if !reflect.DeepEqual(plan.ToInstall, wantInstall) {
+		t.Errorf("ToInstall = %v, want %v", plan.ToInstall, wantInstall)
+	}
+}
+
+func TestSelect_UnknownItem(t *testing.T) {
+	m := fixtureManifest(t)
+	_, err := Select(m, Selection{}, "does-not-exist")
+	if !errors.Is(err, ErrUnknownItem) {
+		t.Errorf("err = %v, want ErrUnknownItem", err)
+	}
+}
+
+func TestDeselect_CascadesToDependents(t *testing.T) {
+	m := fixtureManifest(t)
+	current := Selection{"git": true, "git-delta": true, "lazygit": true}
+
+	plan, err := Deselect(m, current, "git-delta")
+	if err != nil {
+		t.Fatalf("Deselect() error = %v", err)
+	}
+
+	if plan.Selection["git-delta"] || plan.Selection["lazygit"] {
+		t.Errorf("Selection = %v, want both deselected", plan.Selection)
+	}
+	if !plan.Selection["git"] {
+		t.Errorf("Selection[git] = false, want true (git wasn't targeted)")
+	}
+	wantCascade := []string{"lazygit"}
+	if !reflect.DeepEqual(plan.CascadeDeselected, wantCascade) {
+		t.Errorf("CascadeDeselected = %v, want %v", plan.CascadeDeselected, wantCascade)
+	}
+	wantUninstall := []string{"git-delta", "lazygit"}
+	if !reflect.DeepEqual(plan.ToUninstall, wantUninstall) {
+		t.Errorf("ToUninstall = %v, want %v", plan.ToUninstall, wantUninstall)
+	}
+}
+
+func TestDeselect_RefusesCoreItem(t *testing.T) {
+	m := fixtureManifest(t)
+	current := Selection{"git": true}
+
+	_, err := Deselect(m, current, "git")
+	if !errors.Is(err, ErrCoreItemUninstall) {
+		t.Errorf("err = %v, want ErrCoreItemUninstall", err)
+	}
+}
+
+func TestDeselect_RefusesWhenCascadeWouldHitCoreItem(t *testing.T) {
+	m, err := NewManifest([]Item{
+		{ID: "base", Tier: TierOptional},
+		{ID: "depends-on-base", Tier: TierCore, Dependencies: []string{"base"}},
+	})
+	if err != nil {
+		t.Fatalf("NewManifest() error = %v", err)
+	}
+	current := Selection{"base": true, "depends-on-base": true}
+
+	_, err = Deselect(m, current, "base")
+	if !errors.Is(err, ErrCoreItemUninstall) {
+		t.Errorf("err = %v, want ErrCoreItemUninstall", err)
+	}
+}
+
+func TestSelectCategory_SelectsEveryItemAndDeps(t *testing.T) {
+	m := fixtureManifest(t)
+
+	plan, err := SelectCategory(m, Selection{}, "essentials")
+	if err != nil {
+		t.Fatalf("SelectCategory() error = %v", err)
+	}
+
+	for _, id := range []string{"git", "git-delta", "starship"} {
+		if !plan.Selection[id] {
+			t.Errorf("Selection[%q] = false, want true", id)
+		}
+	}
+	if plan.Selection["nvidia"] {
+		t.Errorf("Selection[nvidia] = true, want false (different category)")
+	}
+}
+
+func TestSelectCategory_UnknownCategory(t *testing.T) {
+	m := fixtureManifest(t)
+	_, err := SelectCategory(m, Selection{}, "does-not-exist")
+	if err == nil {
+		t.Fatal("expected error for unknown category, got nil")
+	}
+}
+
+func TestDeselectCategory_LeavesCoreItemsSelected(t *testing.T) {
+	m := fixtureManifest(t)
+	current := Selection{"git": true, "git-delta": true, "starship": true}
+
+	plan, err := DeselectCategory(m, current, "essentials")
+	if err != nil {
+		t.Fatalf("DeselectCategory() error = %v", err)
+	}
+
+	if !plan.Selection["git"] {
+		t.Errorf("Selection[git] = false, want true (core item left alone)")
+	}
+	if plan.Selection["git-delta"] || plan.Selection["starship"] {
+		t.Errorf("Selection = %v, want git-delta and starship deselected", plan.Selection)
+	}
+}
+
+func TestDiff_ComputesInstallAndUninstall(t *testing.T) {
+	current := Selection{"a": true, "b": true}
+	desired := Selection{"b": true, "c": true}
+
+	plan := Diff(current, desired)
+
+	if want := []string{"c"}; !reflect.DeepEqual(plan.ToInstall, want) {
+		t.Errorf("ToInstall = %v, want %v", plan.ToInstall, want)
+	}
+	if want := []string{"a"}; !reflect.DeepEqual(plan.ToUninstall, want) {
+		t.Errorf("ToUninstall = %v, want %v", plan.ToUninstall, want)
+	}
+}
+
+func TestManifest_ItemsByCategoryPreservesDeclarationOrder(t *testing.T) {
+	m := fixtureManifest(t)
+	items := m.ItemsByCategory("essentials")
+	var ids []string
+	for _, it := range items {
+		ids = append(ids, it.ID)
+	}
+	want := []string{"git", "git-delta", "lazygit", "starship"}
+	if !reflect.DeepEqual(ids, want) {
+		t.Errorf("ItemsByCategory ids = %v, want %v", ids, want)
+	}
+}

--- a/dfa/internal/catalogfs/load.go
+++ b/dfa/internal/catalogfs/load.go
@@ -1,0 +1,93 @@
+// Package catalogfs loads catalog.Manifest data from TOML files on disk —
+// the filesystem I/O the pure catalog package deliberately excludes.
+package catalogfs
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/mikedelafuente/dotfiles-arch/dfa/internal/catalog"
+)
+
+// itemFile mirrors one manifest TOML file's shape.
+type itemFile struct {
+	ID           string   `toml:"id"`
+	Name         string   `toml:"name"`
+	Description  string   `toml:"description"`
+	Categories   []string `toml:"categories"`
+	Tier         string   `toml:"tier"`
+	Capabilities []string `toml:"capabilities"`
+	Dependencies []string `toml:"dependencies"`
+	SetupScript  string   `toml:"setup_script"`
+	Packages     struct {
+		Pacman []string `toml:"pacman"`
+		AUR    []string `toml:"aur"`
+	} `toml:"packages"`
+}
+
+// LoadDir reads every *.toml file directly under dir (one Software Item per
+// file, filenames not otherwise meaningful) and returns a validated
+// catalog.Manifest. Files are read in sorted filename order for
+// deterministic output.
+func LoadDir(dir string) (catalog.Manifest, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return catalog.Manifest{}, fmt.Errorf("catalogfs: reading %s: %w", dir, err)
+	}
+
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".toml" {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+
+	items := make([]catalog.Item, 0, len(names))
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		it, err := loadItemFile(path)
+		if err != nil {
+			return catalog.Manifest{}, err
+		}
+		items = append(items, it)
+	}
+
+	return catalog.NewManifest(items)
+}
+
+func loadItemFile(path string) (catalog.Item, error) {
+	var f itemFile
+	if _, err := toml.DecodeFile(path, &f); err != nil {
+		return catalog.Item{}, fmt.Errorf("catalogfs: parsing %s: %w", path, err)
+	}
+	if f.ID == "" {
+		return catalog.Item{}, fmt.Errorf("catalogfs: %s: missing required field %q", path, "id")
+	}
+	if f.Description == "" {
+		return catalog.Item{}, fmt.Errorf("catalogfs: %s: missing required field %q", path, "description")
+	}
+	if f.SetupScript == "" {
+		return catalog.Item{}, fmt.Errorf("catalogfs: %s: missing required field %q", path, "setup_script")
+	}
+
+	return catalog.Item{
+		ID:           f.ID,
+		Name:         f.Name,
+		Description:  f.Description,
+		Categories:   f.Categories,
+		Tier:         catalog.Tier(f.Tier),
+		Capabilities: f.Capabilities,
+		Dependencies: f.Dependencies,
+		Packages: catalog.Packages{
+			Pacman: f.Packages.Pacman,
+			AUR:    f.Packages.AUR,
+		},
+		SetupScript: f.SetupScript,
+	}, nil
+}

--- a/dfa/internal/catalogfs/load_test.go
+++ b/dfa/internal/catalogfs/load_test.go
@@ -1,0 +1,135 @@
+package catalogfs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("writing fixture %s: %v", name, err)
+	}
+}
+
+func TestLoadDir_ParsesItemsInSortedFilenameOrder(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "git-delta.toml", `
+id = "git-delta"
+name = "git-delta"
+description = "Side-by-side syntax-highlighted git diffs."
+categories = ["essentials"]
+tier = "optional"
+dependencies = ["git"]
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["git-delta"]
+`)
+	writeFile(t, dir, "git.toml", `
+id = "git"
+name = "git"
+description = "Distributed version control."
+categories = ["essentials"]
+tier = "core"
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["git"]
+`)
+
+	m, err := LoadDir(dir)
+	if err != nil {
+		t.Fatalf("LoadDir() error = %v", err)
+	}
+
+	items := m.ItemsByCategory("essentials")
+	if len(items) != 2 {
+		t.Fatalf("len(items) = %d, want 2", len(items))
+	}
+	// git-delta.toml sorts before git.toml, so filename order puts
+	// git-delta first even though git is its dependency.
+	if items[0].ID != "git-delta" || items[1].ID != "git" {
+		t.Errorf("items = [%s, %s], want [git-delta, git]", items[0].ID, items[1].ID)
+	}
+
+	delta, ok := m.Item("git-delta")
+	if !ok {
+		t.Fatal("git-delta not found")
+	}
+	if delta.Description != "Side-by-side syntax-highlighted git diffs." {
+		t.Errorf("Description = %q", delta.Description)
+	}
+	if len(delta.Packages.Pacman) != 1 || delta.Packages.Pacman[0] != "git-delta" {
+		t.Errorf("Packages.Pacman = %v", delta.Packages.Pacman)
+	}
+	if delta.SetupScript != "setup-essentials.sh" {
+		t.Errorf("SetupScript = %q", delta.SetupScript)
+	}
+}
+
+func TestLoadDir_RejectsMissingRequiredFields(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "broken.toml", `
+name = "broken"
+description = "Missing an id."
+setup_script = "setup-essentials.sh"
+`)
+
+	if _, err := LoadDir(dir); err == nil {
+		t.Fatal("expected error for missing id, got nil")
+	}
+}
+
+func TestLoadDir_PropagatesManifestValidationErrors(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "orphan.toml", `
+id = "orphan"
+name = "orphan"
+description = "Depends on something that doesn't exist."
+tier = "optional"
+dependencies = ["ghost"]
+setup_script = "setup-essentials.sh"
+`)
+
+	if _, err := LoadDir(dir); err == nil {
+		t.Fatal("expected error for unknown dependency, got nil")
+	}
+}
+
+func TestLoadDir_MissingDirectory(t *testing.T) {
+	if _, err := LoadDir(filepath.Join(t.TempDir(), "does-not-exist")); err == nil {
+		t.Fatal("expected error for missing directory, got nil")
+	}
+}
+
+// TestLoadDir_LoadsTheRealEssentialsManifest guards against a bad TOML file
+// under dfa/catalog/items breaking every dfa build — it's the one directory
+// this package ships needing runtime, not just fixture, validation.
+func TestLoadDir_LoadsTheRealEssentialsManifest(t *testing.T) {
+	m, err := LoadDir(filepath.Join("..", "..", "catalog", "items"))
+	if err != nil {
+		t.Fatalf("LoadDir(catalog/items) error = %v", err)
+	}
+
+	items := m.ItemsByCategory("essentials")
+	if len(items) == 0 {
+		t.Fatal("expected at least one essentials item, got none")
+	}
+	for _, it := range items {
+		if it.Description == "" {
+			t.Errorf("item %q has an empty description", it.ID)
+		}
+		if len(it.Packages.Pacman) == 0 && len(it.Packages.AUR) == 0 {
+			t.Errorf("item %q declares no packages", it.ID)
+		}
+		if it.SetupScript != "setup-essentials.sh" {
+			t.Errorf("item %q has setup_script %q, want setup-essentials.sh", it.ID, it.SetupScript)
+		}
+	}
+
+	if _, ok := m.Item("git"); !ok {
+		t.Error(`expected "git" item to exist`)
+	}
+}

--- a/dfa/internal/dashboard/dashboard.go
+++ b/dfa/internal/dashboard/dashboard.go
@@ -1,16 +1,31 @@
 // Package dashboard implements the top-level dfa dashboard: a Bubble Tea
-// list of every planned dfa screen. Only the shell is wired up so far — most
-// entries are placeholders that later work will turn into real screens.
+// list of every planned dfa screen. "Install/Uninstall Software" is wired
+// up to the real Catalog Engine + software screen; the rest remain
+// placeholders that later work will turn into real screens.
 package dashboard
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/mikedelafuente/dotfiles-arch/dfa/internal/catalog"
+	"github.com/mikedelafuente/dotfiles-arch/dfa/internal/catalogfs"
+	"github.com/mikedelafuente/dotfiles-arch/dfa/internal/software"
+	"github.com/mikedelafuente/dotfiles-arch/dfa/internal/system"
 )
+
+// installSoftwareTitle identifies the one screen entry that's wired up to
+// the real Catalog Engine rather than being a placeholder.
+const installSoftwareTitle = "Install/Uninstall Software"
+
+// essentialsCategory is the only category the Install/Uninstall Software
+// screen exposes so far — later tickets grow the rest of the taxonomy.
+const essentialsCategory = "essentials"
 
 // screenItem is one row in the dashboard list: a planned dfa screen.
 type screenItem struct {
@@ -22,14 +37,14 @@ func (i screenItem) Title() string       { return i.title }
 func (i screenItem) Description() string { return i.description }
 func (i screenItem) FilterValue() string { return i.title }
 
-// screens is the full set of planned dfa dashboard screens. Every entry is
-// a placeholder for now — later work implements the real behavior behind
-// each one.
+// screens is the full set of planned dfa dashboard screens. Every entry
+// besides Install/Uninstall Software is a placeholder for now — later work
+// implements the real behavior behind each one.
 func screens() []screenItem {
 	return []screenItem{
 		{
-			title:       "Install/Uninstall Software",
-			description: "Browse the software catalog and select what's installed (not yet implemented)",
+			title:       installSoftwareTitle,
+			description: "Browse the software catalog and select what's installed",
 		},
 		{
 			title:       "Repos",
@@ -78,11 +93,18 @@ var (
 type Model struct {
 	list     list.Model
 	selected *screenItem
+	software *software.Model
 	quitting bool
+
+	repoRoot    string
+	manifest    catalog.Manifest
+	manifestErr error
 }
 
-// New builds a dashboard Model listing every planned dfa screen.
-func New() Model {
+// New builds a dashboard Model listing every planned dfa screen. repoRoot is
+// the dotfiles-arch checkout root (see system.FindRepoRoot) used to locate
+// the catalog manifest and setup-*.sh scripts.
+func New(repoRoot string) Model {
 	scr := screens()
 	items := make([]list.Item, len(scr))
 	for i, s := range scr {
@@ -96,7 +118,9 @@ func New() Model {
 	l.SetFilteringEnabled(false)
 	l.Styles.Title = titleStyle
 
-	return Model{list: l}
+	manifest, err := catalogfs.LoadDir(filepath.Join(repoRoot, "dfa", "catalog", "items"))
+
+	return Model{list: l, repoRoot: repoRoot, manifest: manifest, manifestErr: err}
 }
 
 // Init satisfies tea.Model.
@@ -111,11 +135,26 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.list.SetSize(msg.Width, msg.Height-4)
 		return m, nil
 
+	case software.BackMsg:
+		m.software = nil
+		m.selected = nil
+		return m, nil
+
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "ctrl+c", "q":
 			m.quitting = true
 			return m, tea.Quit
+		}
+
+		if m.software != nil {
+			updated, cmd := m.software.Update(msg)
+			sm := updated.(software.Model)
+			m.software = &sm
+			return m, cmd
+		}
+
+		switch msg.String() {
 		case "esc":
 			if m.selected != nil {
 				m.selected = nil
@@ -124,6 +163,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "enter":
 			if item, ok := m.list.SelectedItem().(screenItem); ok {
 				m.selected = &item
+				if item.title == installSoftwareTitle {
+					m.enterSoftwareScreen()
+				}
 			}
 			return m, nil
 		}
@@ -134,17 +176,46 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+// enterSoftwareScreen builds the real software.Model for the Essentials
+// category, seeding its starting selection from what's actually installed
+// on the machine. No-ops (leaving the placeholder in place) if the catalog
+// manifest failed to load.
+func (m *Model) enterSoftwareScreen() {
+	if m.manifestErr != nil {
+		return
+	}
+
+	selection := catalog.Selection{}
+	for _, item := range m.manifest.ItemsByCategory(essentialsCategory) {
+		if installed, err := system.QueryPackagesInstalled(item.Packages.Pacman); err == nil && installed {
+			selection[item.ID] = true
+		}
+	}
+
+	runner := software.ScriptsDirRunner{ScriptsDir: filepath.Join(m.repoRoot, "scripts")}
+	sm := software.New(m.manifest, essentialsCategory, selection, runner)
+	m.software = &sm
+}
+
 // View satisfies tea.Model.
 func (m Model) View() string {
 	if m.quitting {
 		return ""
 	}
 
+	if m.software != nil {
+		return m.software.View()
+	}
+
 	if m.selected != nil {
 		var b strings.Builder
 		b.WriteString(titleStyle.Render(m.selected.title))
 		b.WriteString("\n")
-		b.WriteString(placeholderStyle.Render(placeholderNotice))
+		notice := placeholderNotice
+		if m.selected.title == installSoftwareTitle && m.manifestErr != nil {
+			notice = fmt.Sprintf("Could not load the software catalog: %v", m.manifestErr)
+		}
+		b.WriteString(placeholderStyle.Render(notice))
 		b.WriteString("\n")
 		b.WriteString(helpStyle.Render("esc: back to dashboard  •  q: quit"))
 		return b.String()
@@ -157,8 +228,8 @@ func (m Model) View() string {
 }
 
 // Run starts the dashboard Bubble Tea program and blocks until it quits.
-func Run() error {
-	p := tea.NewProgram(New(), tea.WithAltScreen())
+func Run(repoRoot string) error {
+	p := tea.NewProgram(New(repoRoot), tea.WithAltScreen())
 	_, err := p.Run()
 	return err
 }

--- a/dfa/internal/dashboard/dashboard_test.go
+++ b/dfa/internal/dashboard/dashboard_test.go
@@ -1,10 +1,47 @@
 package dashboard
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
+
+// writeFixtureRepo builds a minimal repo skeleton (catalog manifest +
+// scripts dir) so tests can exercise the real Install/Uninstall Software
+// wiring without touching the actual dotfiles-arch checkout.
+func writeFixtureRepo(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+
+	itemsDir := filepath.Join(root, "dfa", "catalog", "items")
+	if err := os.MkdirAll(itemsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(itemsDir): %v", err)
+	}
+	item := `
+id = "dfa-test-fixture-item"
+name = "Fixture Item"
+description = "A fixture item used only by dashboard tests."
+categories = ["essentials"]
+tier = "optional"
+setup_script = "setup-essentials.sh"
+
+[packages]
+pacman = ["dfa-test-fixture-package-does-not-exist"]
+`
+	if err := os.WriteFile(filepath.Join(itemsDir, "fixture.toml"), []byte(item), 0o644); err != nil {
+		t.Fatalf("WriteFile(fixture.toml): %v", err)
+	}
+
+	scriptsDir := filepath.Join(root, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(scriptsDir): %v", err)
+	}
+
+	return root
+}
 
 func TestScreens_ListsAllSevenPlannedScreens(t *testing.T) {
 	want := []string{
@@ -32,7 +69,7 @@ func TestScreens_ListsAllSevenPlannedScreens(t *testing.T) {
 }
 
 func TestUpdate_QuitsOnQ(t *testing.T) {
-	m := New()
+	m := New(t.TempDir())
 
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("q")})
 	dm := updated.(Model)
@@ -49,7 +86,7 @@ func TestUpdate_QuitsOnQ(t *testing.T) {
 }
 
 func TestUpdate_QuitsOnCtrlC(t *testing.T) {
-	m := New()
+	m := New(t.TempDir())
 
 	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
 	dm := updated.(Model)
@@ -63,7 +100,7 @@ func TestUpdate_QuitsOnCtrlC(t *testing.T) {
 }
 
 func TestUpdate_EnterSelectsThenEscReturnsToList(t *testing.T) {
-	m := New()
+	m := New(t.TempDir())
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	dm := updated.(Model)
@@ -82,8 +119,39 @@ func TestUpdate_EnterSelectsThenEscReturnsToList(t *testing.T) {
 	}
 }
 
+func TestUpdate_EnterOnInstallSoftwareOpensRealSoftwareScreen(t *testing.T) {
+	m := New(writeFixtureRepo(t))
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	dm := updated.(Model)
+
+	if dm.software == nil {
+		t.Fatalf("software == nil after opening Install/Uninstall Software, want the real screen wired up (manifestErr: %v)", dm.manifestErr)
+	}
+	if !strings.Contains(dm.View(), "Fixture Item") {
+		t.Errorf("View() = %q, want it to list the fixture item", dm.View())
+	}
+
+	// Esc from within the software screen returns a BackMsg via Cmd (real
+	// bubbletea usage: the runtime calls cmd() and feeds the result back in).
+	updated, cmd := dm.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	dm = updated.(Model)
+	if cmd == nil {
+		t.Fatalf("expected a Cmd carrying BackMsg after esc from the software screen, got nil")
+	}
+	updated, _ = dm.Update(cmd())
+	dm = updated.(Model)
+
+	if dm.software != nil {
+		t.Errorf("software = %+v after esc, want nil", dm.software)
+	}
+	if dm.selected != nil {
+		t.Errorf("selected = %+v after esc, want nil", dm.selected)
+	}
+}
+
 func TestView_DoesNotPanicBeforeOrAfterSelection(t *testing.T) {
-	m := New()
+	m := New(t.TempDir())
 	if m.View() == "" {
 		t.Errorf("View() on a fresh model should render something")
 	}

--- a/dfa/internal/software/software.go
+++ b/dfa/internal/software/software.go
@@ -1,0 +1,244 @@
+// Package software implements the dfa "Install/Uninstall Software" screen:
+// a Bubble Tea list of one Category's Software Items that drives the
+// Catalog Engine (dfa/internal/catalog) and, on each resulting plan,
+// triggers real installs/uninstalls through a ScriptRunner (the System
+// Adapter in production; a fake in tests).
+package software
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/mikedelafuente/dotfiles-arch/dfa/internal/catalog"
+	"github.com/mikedelafuente/dotfiles-arch/dfa/internal/system"
+)
+
+// ScriptRunner is the seam this screen uses to actually install/uninstall
+// software. The production implementation shells out to the item's
+// setup_script via system.RunScript; tests use a fake that just records
+// calls, per the parent spec's testing decision.
+type ScriptRunner interface {
+	RunScript(scriptPath string, args ...string) (system.Result, error)
+}
+
+// BackMsg is emitted when the user asks to leave this screen.
+type BackMsg struct{}
+
+// ScriptsDirRunner is the production ScriptRunner: it resolves each item's
+// setup_script against a scripts directory (the repo's scripts/) and shells
+// out to it via system.RunScript.
+type ScriptsDirRunner struct {
+	ScriptsDir string
+}
+
+// RunScript satisfies ScriptRunner.
+func (r ScriptsDirRunner) RunScript(scriptName string, args ...string) (system.Result, error) {
+	return system.RunScript(r.ScriptsDir+"/"+scriptName, args...)
+}
+
+var (
+	titleStyle = lipgloss.NewStyle().Bold(true).Padding(0, 1)
+	helpStyle  = lipgloss.NewStyle().Faint(true).Padding(1, 1, 0, 1)
+	lockStyle  = lipgloss.NewStyle().Faint(true)
+	errStyle   = lipgloss.NewStyle().Padding(0, 1)
+	cursorSign = "> "
+	noCursor   = "  "
+)
+
+// Model is the Bubble Tea model for one category's Install/Uninstall
+// Software screen.
+type Model struct {
+	manifest  catalog.Manifest
+	category  string
+	items     []catalog.Item
+	selection catalog.Selection
+	runner    ScriptRunner
+	cursor    int
+	statusMsg string
+}
+
+// New builds a software Model scoped to one category, starting from the
+// given selection (e.g. derived from querying what's currently installed).
+func New(manifest catalog.Manifest, category string, selection catalog.Selection, runner ScriptRunner) Model {
+	return Model{
+		manifest:  manifest,
+		category:  category,
+		items:     manifest.ItemsByCategory(category),
+		selection: selection.Clone(),
+		runner:    runner,
+	}
+}
+
+// Init satisfies tea.Model.
+func (m Model) Init() tea.Cmd { return nil }
+
+// Update satisfies tea.Model.
+func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	keyMsg, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+
+	switch keyMsg.String() {
+	case "up", "k":
+		if m.cursor > 0 {
+			m.cursor--
+		}
+		return m, nil
+
+	case "down", "j":
+		if m.cursor < len(m.items)-1 {
+			m.cursor++
+		}
+		return m, nil
+
+	case "esc":
+		return m, func() tea.Msg { return BackMsg{} }
+
+	case " ", "enter":
+		m.toggleCurrent()
+		return m, nil
+
+	case "a":
+		m.selectAll()
+		return m, nil
+
+	case "u":
+		m.deselectAll()
+		return m, nil
+	}
+
+	return m, nil
+}
+
+func (m *Model) toggleCurrent() {
+	if len(m.items) == 0 {
+		return
+	}
+	item := m.items[m.cursor]
+
+	var plan catalog.Plan
+	var err error
+	if m.selection[item.ID] {
+		plan, err = catalog.Deselect(m.manifest, m.selection, item.ID)
+	} else {
+		plan, err = catalog.Select(m.manifest, m.selection, item.ID)
+	}
+	m.applyPlanOrError(plan, err)
+}
+
+func (m *Model) selectAll() {
+	plan, err := catalog.SelectCategory(m.manifest, m.selection, m.category)
+	m.applyPlanOrError(plan, err)
+}
+
+func (m *Model) deselectAll() {
+	plan, err := catalog.DeselectCategory(m.manifest, m.selection, m.category)
+	m.applyPlanOrError(plan, err)
+}
+
+func (m *Model) applyPlanOrError(plan catalog.Plan, err error) {
+	if err != nil {
+		m.statusMsg = err.Error()
+		return
+	}
+	m.runPlan(plan)
+}
+
+// runPlan executes every install/uninstall in plan and commits the
+// resulting selection. A script failure reverts just that item's selection
+// state (a failed install is not marked selected; a failed uninstall is not
+// marked deselected) so the checkbox never claims success the machine
+// didn't actually deliver.
+func (m *Model) runPlan(plan catalog.Plan) {
+	selection := plan.Selection.Clone()
+	var failures []string
+
+	for _, id := range plan.ToInstall {
+		item, ok := m.manifest.Item(id)
+		if !ok {
+			continue
+		}
+		args := append([]string{"--install"}, item.Packages.Pacman...)
+		if _, err := m.runner.RunScript(item.SetupScript, args...); err != nil {
+			failures = append(failures, fmt.Sprintf("installing %s failed: %v", id, err))
+			selection[id] = false
+		}
+	}
+	for _, id := range plan.ToUninstall {
+		item, ok := m.manifest.Item(id)
+		if !ok {
+			continue
+		}
+		args := append([]string{"--uninstall"}, item.Packages.Pacman...)
+		if _, err := m.runner.RunScript(item.SetupScript, args...); err != nil {
+			failures = append(failures, fmt.Sprintf("uninstalling %s failed: %v", id, err))
+			selection[id] = true
+		}
+	}
+
+	m.selection = selection
+	if len(failures) > 0 {
+		m.statusMsg = strings.Join(failures, " • ")
+		return
+	}
+	m.statusMsg = summarizePlan(plan)
+	if len(plan.CoreItemsSkipped) > 0 {
+		skipped := "left alone (core, locked): " + strings.Join(plan.CoreItemsSkipped, ", ")
+		if m.statusMsg == "" {
+			m.statusMsg = skipped
+		} else {
+			m.statusMsg += " • " + skipped
+		}
+	}
+}
+
+func summarizePlan(plan catalog.Plan) string {
+	if len(plan.ToInstall) == 0 && len(plan.ToUninstall) == 0 {
+		return ""
+	}
+	var parts []string
+	if len(plan.ToInstall) > 0 {
+		parts = append(parts, "installed: "+strings.Join(plan.ToInstall, ", "))
+	}
+	if len(plan.ToUninstall) > 0 {
+		parts = append(parts, "removed: "+strings.Join(plan.ToUninstall, ", "))
+	}
+	return strings.Join(parts, " • ")
+}
+
+// View satisfies tea.Model.
+func (m Model) View() string {
+	var b strings.Builder
+	b.WriteString(titleStyle.Render(fmt.Sprintf("dfa — %s", m.category)))
+	b.WriteString("\n\n")
+
+	for i, item := range m.items {
+		cursor := noCursor
+		if i == m.cursor {
+			cursor = cursorSign
+		}
+		checkbox := "[ ]"
+		if m.selection[item.ID] {
+			checkbox = "[x]"
+		}
+		line := fmt.Sprintf("%s%s %s — %s", cursor, checkbox, item.Name, item.Description)
+		if item.Tier == catalog.TierCore {
+			line = lockStyle.Render(line + " (core, locked)")
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+
+	if m.statusMsg != "" {
+		b.WriteString("\n")
+		b.WriteString(errStyle.Render(m.statusMsg))
+		b.WriteString("\n")
+	}
+
+	b.WriteString(helpStyle.Render("space: toggle  •  a: select all  •  u: deselect all  •  esc: back"))
+	return b.String()
+}

--- a/dfa/internal/software/software_test.go
+++ b/dfa/internal/software/software_test.go
@@ -1,0 +1,260 @@
+package software
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/mikedelafuente/dotfiles-arch/dfa/internal/catalog"
+	"github.com/mikedelafuente/dotfiles-arch/dfa/internal/system"
+)
+
+var errBoom = errors.New("boom")
+
+type scriptCall struct {
+	script string
+	args   []string
+}
+
+// fakeRunner records every RunScript call instead of touching a real
+// machine, per the parent spec's testing decision for TUI-flow tests.
+type fakeRunner struct {
+	calls []scriptCall
+	err   error
+}
+
+func (f *fakeRunner) RunScript(scriptPath string, args ...string) (system.Result, error) {
+	f.calls = append(f.calls, scriptCall{script: scriptPath, args: append([]string(nil), args...)})
+	if f.err != nil {
+		return system.Result{}, f.err
+	}
+	return system.Result{ExitCode: 0}, nil
+}
+
+func fixtureManifest(t *testing.T) catalog.Manifest {
+	t.Helper()
+	m, err := catalog.NewManifest([]catalog.Item{
+		{
+			ID: "git", Name: "git", Description: "Version control",
+			Categories: []string{"essentials"}, Tier: catalog.TierCore,
+			SetupScript: "setup-essentials.sh",
+			Packages:    catalog.Packages{Pacman: []string{"git"}},
+		},
+		{
+			ID: "git-delta", Name: "git-delta", Description: "Better git diffs",
+			Categories: []string{"essentials"}, Tier: catalog.TierOptional,
+			Dependencies: []string{"git"}, SetupScript: "setup-essentials.sh",
+			Packages: catalog.Packages{Pacman: []string{"git-delta"}},
+		},
+		{
+			ID: "starship", Name: "starship", Description: "Shell prompt",
+			Categories: []string{"essentials"}, Tier: catalog.TierOptional,
+			SetupScript: "setup-essentials.sh",
+			Packages:    catalog.Packages{Pacman: []string{"starship"}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManifest() error = %v", err)
+	}
+	return m
+}
+
+func keyMsg(s string) tea.KeyMsg {
+	switch s {
+	case " ":
+		return tea.KeyMsg{Type: tea.KeySpace}
+	case "up":
+		return tea.KeyMsg{Type: tea.KeyUp}
+	case "down":
+		return tea.KeyMsg{Type: tea.KeyDown}
+	default:
+		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
+	}
+}
+
+func TestNew_StartsWithNoSelectionByDefault(t *testing.T) {
+	m := New(fixtureManifest(t), "essentials", catalog.Selection{}, &fakeRunner{})
+	if len(m.items) != 3 {
+		t.Fatalf("len(items) = %d, want 3", len(m.items))
+	}
+	for id := range m.selection {
+		t.Errorf("selection[%q] unexpectedly present in empty starting selection", id)
+	}
+}
+
+func TestUpdate_SpaceSelectsItemAndRunsInstall(t *testing.T) {
+	runner := &fakeRunner{}
+	m := New(fixtureManifest(t), "essentials", catalog.Selection{}, runner)
+	m.cursor = 1 // git-delta
+
+	updated, _ := m.Update(keyMsg(" "))
+	m = updated.(Model)
+
+	if !m.selection["git-delta"] || !m.selection["git"] {
+		t.Errorf("selection = %v, want git-delta and its dependency git selected", m.selection)
+	}
+
+	want := []scriptCall{
+		{script: "setup-essentials.sh", args: []string{"--install", "git"}},
+		{script: "setup-essentials.sh", args: []string{"--install", "git-delta"}},
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Errorf("calls = %+v, want %+v", runner.calls, want)
+	}
+}
+
+func TestUpdate_SpaceTogglesBackToDeselectAndRunsUninstall(t *testing.T) {
+	runner := &fakeRunner{}
+	current := catalog.Selection{"git": true, "starship": true}
+	m := New(fixtureManifest(t), "essentials", current, runner)
+	m.cursor = 2 // starship
+
+	updated, _ := m.Update(keyMsg(" "))
+	m = updated.(Model)
+
+	if m.selection["starship"] {
+		t.Errorf("selection[starship] = true, want false after toggling off")
+	}
+	want := []scriptCall{
+		{script: "setup-essentials.sh", args: []string{"--uninstall", "starship"}},
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Errorf("calls = %+v, want %+v", runner.calls, want)
+	}
+}
+
+func TestUpdate_SpaceOnCoreItemRefusesAndShowsError(t *testing.T) {
+	runner := &fakeRunner{}
+	current := catalog.Selection{"git": true}
+	m := New(fixtureManifest(t), "essentials", current, runner)
+	m.cursor = 0 // git (core)
+
+	updated, _ := m.Update(keyMsg(" "))
+	m = updated.(Model)
+
+	if !m.selection["git"] {
+		t.Errorf("selection[git] = false, want still true (core item locked)")
+	}
+	if m.statusMsg == "" {
+		t.Errorf("expected a status message explaining the refusal, got empty string")
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("calls = %+v, want no script invocations", runner.calls)
+	}
+}
+
+func TestUpdate_SelectAllInCategory(t *testing.T) {
+	runner := &fakeRunner{}
+	m := New(fixtureManifest(t), "essentials", catalog.Selection{}, runner)
+
+	updated, _ := m.Update(keyMsg("a"))
+	m = updated.(Model)
+
+	for _, id := range []string{"git", "git-delta", "starship"} {
+		if !m.selection[id] {
+			t.Errorf("selection[%q] = false, want true after select-all", id)
+		}
+	}
+	if len(runner.calls) != 3 {
+		t.Errorf("len(calls) = %d, want 3 (one install per item)", len(runner.calls))
+	}
+}
+
+func TestUpdate_DeselectAllInCategoryLeavesCoreItems(t *testing.T) {
+	runner := &fakeRunner{}
+	current := catalog.Selection{"git": true, "git-delta": true, "starship": true}
+	m := New(fixtureManifest(t), "essentials", current, runner)
+
+	updated, _ := m.Update(keyMsg("u"))
+	m = updated.(Model)
+
+	if !m.selection["git"] {
+		t.Errorf("selection[git] = false, want true (core item left selected)")
+	}
+	if m.selection["git-delta"] || m.selection["starship"] {
+		t.Errorf("selection = %v, want git-delta and starship deselected", m.selection)
+	}
+	want := []scriptCall{
+		{script: "setup-essentials.sh", args: []string{"--uninstall", "git-delta"}},
+		{script: "setup-essentials.sh", args: []string{"--uninstall", "starship"}},
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Errorf("calls = %+v, want %+v", runner.calls, want)
+	}
+}
+
+func TestUpdate_FailedInstallDoesNotMarkItemSelected(t *testing.T) {
+	runner := &fakeRunner{err: errBoom}
+	m := New(fixtureManifest(t), "essentials", catalog.Selection{"git": true}, runner)
+	m.cursor = 2 // starship
+
+	updated, _ := m.Update(keyMsg(" "))
+	m = updated.(Model)
+
+	if m.selection["starship"] {
+		t.Errorf("selection[starship] = true, want false (install script failed)")
+	}
+	if m.statusMsg == "" {
+		t.Errorf("expected a failure status message, got empty string")
+	}
+}
+
+func TestUpdate_FailedUninstallLeavesItemSelected(t *testing.T) {
+	runner := &fakeRunner{err: errBoom}
+	current := catalog.Selection{"git": true, "starship": true}
+	m := New(fixtureManifest(t), "essentials", current, runner)
+	m.cursor = 2 // starship
+
+	updated, _ := m.Update(keyMsg(" "))
+	m = updated.(Model)
+
+	if !m.selection["starship"] {
+		t.Errorf("selection[starship] = false, want true (uninstall script failed, so it's still there)")
+	}
+}
+
+func TestUpdate_DeselectAllReportsCoreItemsLeftAlone(t *testing.T) {
+	runner := &fakeRunner{}
+	current := catalog.Selection{"git": true, "starship": true}
+	m := New(fixtureManifest(t), "essentials", current, runner)
+
+	updated, _ := m.Update(keyMsg("u"))
+	m = updated.(Model)
+
+	if !strings.Contains(m.statusMsg, "git") {
+		t.Errorf("statusMsg = %q, want it to mention the core item left alone", m.statusMsg)
+	}
+}
+
+func TestUpdate_CursorMovesWithinBounds(t *testing.T) {
+	m := New(fixtureManifest(t), "essentials", catalog.Selection{}, &fakeRunner{})
+
+	updated, _ := m.Update(keyMsg("up"))
+	m = updated.(Model)
+	if m.cursor != 0 {
+		t.Errorf("cursor = %d, want 0 (clamped at top)", m.cursor)
+	}
+
+	for i := 0; i < 5; i++ {
+		updated, _ = m.Update(keyMsg("down"))
+		m = updated.(Model)
+	}
+	if m.cursor != 2 {
+		t.Errorf("cursor = %d, want 2 (clamped at bottom)", m.cursor)
+	}
+}
+
+func TestUpdate_EscRequestsBack(t *testing.T) {
+	m := New(fixtureManifest(t), "essentials", catalog.Selection{}, &fakeRunner{})
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	if cmd == nil {
+		t.Fatal("expected a Cmd for esc, got nil")
+	}
+	if msg := cmd(); msg != (BackMsg{}) {
+		t.Errorf("cmd() = %#v, want BackMsg{}", msg)
+	}
+}

--- a/dfa/internal/system/system.go
+++ b/dfa/internal/system/system.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 )
 
 // Result captures the outcome of running an external command: its captured
@@ -47,4 +49,82 @@ func Run(name string, args ...string) (Result, error) {
 
 	result.ExitCode = 0
 	return result, nil
+}
+
+// RunScript runs a dotfiles-arch setup-*.sh script (via bash) with the given
+// arguments, capturing its output the same way Run does.
+func RunScript(scriptPath string, args ...string) (Result, error) {
+	return Run("bash", append([]string{scriptPath}, args...)...)
+}
+
+// QueryPackagesInstalled reports whether every named pacman package is
+// currently installed on this machine. An empty package list is trivially
+// "installed" (there's nothing to check).
+func QueryPackagesInstalled(pkgs []string) (bool, error) {
+	if len(pkgs) == 0 {
+		return true, nil
+	}
+	result, err := Run("pacman", append([]string{"-Q"}, pkgs...)...)
+	if err != nil {
+		return false, err
+	}
+	return result.ExitCode == 0, nil
+}
+
+// FindRepoRoot walks up from startDir looking for the dotfiles-arch repo
+// root, identified the same way dotfiles-arch-lib.sh's resolve_dotfiles_arch
+// identifies it from installed ~/.local/bin helpers: the presence of
+// scripts/sync.sh.
+func FindRepoRoot(startDir string) (string, error) {
+	dir := startDir
+	for {
+		if isRepoRoot(dir) {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("system: could not find dotfiles-arch repo root above %s", startDir)
+		}
+		dir = parent
+	}
+}
+
+// isRepoRoot reports whether dir looks like a dotfiles-arch checkout (the
+// same marker FindRepoRoot walks up looking for).
+func isRepoRoot(dir string) bool {
+	fi, err := os.Stat(filepath.Join(dir, "scripts", "sync.sh"))
+	return err == nil && !fi.IsDir()
+}
+
+// ResolveRepoRoot finds the dotfiles-arch checkout dfa is running against,
+// mirroring dotfiles-arch-lib.sh's resolve_dotfiles_arch: walk up from
+// startDir (the running binary's own location — when the binary lives
+// inside a checkout, e.g. `go run`/`go test`, or a dev symlink), then
+// $DOTFILES_ARCH, then a fixed list of common clone paths. This is what
+// lets an installed ~/.local/bin/dfa binary — which no longer lives inside
+// the repo — find it.
+func ResolveRepoRoot(startDir string) (string, error) {
+	if root, err := FindRepoRoot(startDir); err == nil {
+		return root, nil
+	}
+
+	if env := os.Getenv("DOTFILES_ARCH"); env != "" && isRepoRoot(env) {
+		return env, nil
+	}
+
+	home, herr := os.UserHomeDir()
+	if herr == nil {
+		for _, candidate := range []string{
+			filepath.Join(home, "repos", "dotfiles-arch"),
+			filepath.Join(home, "repos", "mikedelafuente", "dotfiles-arch"),
+			filepath.Join(home, "dotfiles-arch"),
+			filepath.Join(home, "src", "dotfiles-arch"),
+		} {
+			if isRepoRoot(candidate) {
+				return candidate, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("system: could not locate the dotfiles-arch repo (checked %s, $DOTFILES_ARCH, and common clone paths)", startDir)
 }

--- a/dfa/internal/system/system_test.go
+++ b/dfa/internal/system/system_test.go
@@ -4,6 +4,8 @@
 package system
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -77,5 +79,63 @@ func TestRun_NonexistentCommand(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "dfa-this-command-does-not-exist-anywhere") {
 		t.Errorf("error %q should mention the command name", err.Error())
+	}
+}
+
+func TestFindRepoRoot_FindsRootFromNestedDir(t *testing.T) {
+	root := t.TempDir()
+	scriptsDir := filepath.Join(root, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scriptsDir, "sync.sh"), []byte("#!/bin/bash\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	nested := filepath.Join(root, "dfa", "internal", "system")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	got, err := FindRepoRoot(nested)
+	if err != nil {
+		t.Fatalf("FindRepoRoot() error = %v", err)
+	}
+	if got != root {
+		t.Errorf("FindRepoRoot() = %q, want %q", got, root)
+	}
+}
+
+func TestFindRepoRoot_ErrorsWhenNotFound(t *testing.T) {
+	if _, err := FindRepoRoot(t.TempDir()); err == nil {
+		t.Fatal("expected error when no repo root exists above startDir, got nil")
+	}
+}
+
+func TestResolveRepoRoot_FallsBackToDOTFILES_ARCHEnvVar(t *testing.T) {
+	root := t.TempDir()
+	scriptsDir := filepath.Join(root, "scripts")
+	if err := os.MkdirAll(scriptsDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scriptsDir, "sync.sh"), []byte("#!/bin/bash\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Setenv("DOTFILES_ARCH", root)
+
+	got, err := ResolveRepoRoot(t.TempDir())
+	if err != nil {
+		t.Fatalf("ResolveRepoRoot() error = %v", err)
+	}
+	if got != root {
+		t.Errorf("ResolveRepoRoot() = %q, want %q", got, root)
+	}
+}
+
+func TestResolveRepoRoot_ErrorsWhenNothingMatches(t *testing.T) {
+	t.Setenv("DOTFILES_ARCH", "")
+	t.Setenv("HOME", t.TempDir())
+
+	if _, err := ResolveRepoRoot(t.TempDir()); err == nil {
+		t.Fatal("expected error when nothing matches, got nil")
 	}
 }

--- a/dfa/main.go
+++ b/dfa/main.go
@@ -7,8 +7,10 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/mikedelafuente/dotfiles-arch/dfa/internal/dashboard"
+	"github.com/mikedelafuente/dotfiles-arch/dfa/internal/system"
 )
 
 func main() {
@@ -32,7 +34,18 @@ func main() {
 		}
 	}
 
-	if err := dashboard.Run(); err != nil {
+	exe, err := os.Executable()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "dfa: locating own executable: %v\n", err)
+		os.Exit(1)
+	}
+	repoRoot, err := system.ResolveRepoRoot(filepath.Dir(exe))
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "dfa: %v\n", err)
+		os.Exit(1)
+	}
+
+	if err := dashboard.Run(repoRoot); err != nil {
 		fmt.Fprintf(os.Stderr, "dfa: %v\n", err)
 		os.Exit(1)
 	}

--- a/scripts/setup-essentials.sh
+++ b/scripts/setup-essentials.sh
@@ -13,6 +13,25 @@ else
   exit 1
 fi
 
+# dfa (the Catalog Engine's System Adapter) drives individual Essentials
+# catalog items through this script one package at a time, rather than the
+# full ESSENTIAL_PACKAGES bundle below. Keep this a thin pass-through to the
+# shared ensure_pacman_pkgs/remove_pacman_pkgs helpers so behavior (and its
+# IoC/AUR guarding, if ever needed here) stays identical either way it's
+# invoked.
+case "${1:-}" in
+  --install)
+    shift
+    ensure_pacman_pkgs "$@"
+    exit $?
+    ;;
+  --uninstall)
+    shift
+    remove_pacman_pkgs "$@"
+    exit $?
+    ;;
+esac
+
 print_tool_setup_start "Essential Packages"
 
 # Keep PACKAGES.md in sync when changing this list


### PR DESCRIPTION
## Summary
- Adds a pure Go Catalog Engine (`dfa/internal/catalog`, no filesystem/exec/network) that computes install/uninstall plans from a Manifest + Selection: dependency auto-select, cascade-deselect, and Core-item uninstall refusal.
- Adds a one-file-per-item TOML manifest format (`id`, `name`, `description`, `categories`, `tier`, `capabilities`, `dependencies`, `packages`, `setup_script`), loaded by `dfa/internal/catalogfs`, and declares the 27 Essentials packages under `dfa/catalog/items/`.
- Wires the dashboard's "Install/Uninstall Software" entry to a real screen (`dfa/internal/software`) that lists the Essentials category, supports per-item and select-all/deselect-all-in-category toggling, and drives real installs/uninstalls through a `ScriptRunner` seam backed by new `--install`/`--uninstall` modes on `setup-essentials.sh` (reusing `ensure_pacman_pkgs`/`remove_pacman_pkgs`).
- Extends the System Adapter with `RunScript`, `QueryPackagesInstalled`, and repo-root resolution (`FindRepoRoot`/`ResolveRepoRoot`, mirroring `resolve_dotfiles_arch`) so an installed `~/.local/bin/dfa` binary can find the catalog and scripts.

Closes #39

## Test plan
- [x] `go test ./...` in `dfa/` (34 tests, including Catalog Engine unit tests on in-memory fixtures and TUI-flow tests via a fake `ScriptRunner`)
- [x] `bash scripts/check.sh` (bash -n + shellcheck) clean
- [x] Manually built `dfa` and drove the Install/Uninstall Software screen against real `pacman` state (toggle, select-all, deselect-all)
- [x] Two-axis code review (Standards + Spec) run against the diff; findings addressed (failed install/uninstall no longer falsely marks an item as changed; core-items-left-alone now surfaces in the status message; minor duplication cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151iieyNBPhYJwADzZ2CDBh