### PR TITLE
fix(bashrc): guard cp/mv/rm -i aliases to interactive shells only

### DIFF
--- a/home/.bashrc
+++ b/home/.bashrc
@@ -101,9 +101,18 @@ else
 fi
 alias grep='grep --color=auto'
 alias mkdir='mkdir -pv'
-alias cp='cp -i'
-alias mv='mv -i'
-alias rm='rm -i'
+# Confirm-before-overwrite/delete only in real interactive terminals. This
+# shell's alias expansion is on regardless of interactivity (see `shopt
+# expand_aliases`), so without this guard a non-interactive caller (an agent
+# driving bash, a script) that runs a bare cp/mv/rm hangs forever on a `-i`
+# prompt nobody can answer.
+case $- in
+  *i*)
+    alias cp='cp -i'
+    alias mv='mv -i'
+    alias rm='rm -i'
+    ;;
+esac
 
 # Git
 alias ga='git add'


### PR DESCRIPTION
## Summary
- `home/.bashrc` aliased `cp`/`mv`/`rm` to their `-i` (confirm-before-overwrite/delete) forms unconditionally.
- This shell's alias expansion is on even in non-interactive shells, so an agent (or script) driving bash that runs a bare `rm`/`cp`/`mv` hangs forever on a confirmation prompt nobody can answer — observed as Claude Code's Bash tool commands hanging mid-session.
- Guard the three aliases behind `case $- in *i*)` so real interactive terminals (Kitty, GNOME Terminal) keep the safety net exactly as before, while non-interactive callers get plain `cp`/`mv`/`rm`.

## Test plan
- [x] `bash -n home/.bashrc`
- [x] Verified non-interactive shell (`bash -c`) no longer aliases `rm`
- [x] Verified interactive shell (`bash -ic`) still aliases `rm='rm -i'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFnHa8g8ak7bxW7uoi1hdf