### PR TITLE
feat(dfa): add Capability gating to the Catalog Engine, proven with NVIDIA

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,8 @@ Bash scripts plus symlinked configs — no build system, no test suite.
 
 1. Read/write saved settings only via `load_bootstrap_config` / `write_bootstrap_config`
    (`FULL_NAME`, `EMAIL_ADDRESS`, `SETUP_PROFILES` multi-select, `SETUP_PROFILE` primary,
-   `INSTALL_NVIDIA`, `MACHINE_TYPE`).
+   `MACHINE_TYPE`). NVIDIA driver install is not a saved setting — it's an ordinary
+   `dfa` catalog item gated on the "NVIDIA GPU detected" capability.
 2. Use `USER_HOME_DIR`; machines have different usernames.
 3. No new `curl | bash` installers; AUR goes through the IoC-scanning helpers.
 4. Scripts must be safe to re-run — `sync.sh` runs all of them every time.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ cd /path/to/dotfiles-arch
 bash scripts/bootstrap.sh
 ```
 
-Prompts for name, email, **multi-select profiles** (`work`, `personal`, `devcontainer`), **INSTALL_NVIDIA**, and **MACHINE_TYPE** (laptop|desktop; default from `has_battery`), or `--yes` for non-interactive. Then enables multilib, rate-limited guarded package upgrade, installs yay if needed, runs setup scripts, links dotfiles.
+Prompts for name, email, **multi-select profiles** (`work`, `personal`, `devcontainer`), and **MACHINE_TYPE** (laptop|desktop; default from `has_battery`), or `--yes` for non-interactive. Then enables multilib, rate-limited guarded package upgrade, installs yay if needed, runs setup scripts, links dotfiles.
 
 ### Sync (existing / drifted machine)
 
@@ -105,7 +105,7 @@ These scripts (`code`, `zed-agent-init`, `dfa-sync-dotfiles`, `dfa-sync-skills`,
 - Packages: `ensure_pacman_pkgs`, `ensure_yay_installed` (scanned before makepkg), `ensure_yay_pkgs`, `ensure_multilib_enabled`, `safe_system_upgrade`, `remove_orphaned_packages`
 - AUR IoC scan: `aur_scan_*` / `aur_scan_package_tree` (fail closed if neither `rg` nor `grep`; known-IoC gate, not full audit)
 - NVM: `nvm_dir`, `load_nvm` (`~/.config/nvm`, migrates legacy `~/.nvm`)
-- Config: `load_bootstrap_config`, `write_bootstrap_config` (`printf %q`), `validate_bootstrap_profile`, `normalize_setup_profile`, `normalize_setup_profiles`, `has_setup_profile`, `primary_setup_profile`, `resolve_nvidia_preference`, `normalize_machine_type`, `resolve_machine_type`, `machine_is_laptop`, `resolve_default_agent`
+- Config: `load_bootstrap_config`, `write_bootstrap_config` (`printf %q`), `validate_bootstrap_profile`, `normalize_setup_profile`, `normalize_setup_profiles`, `has_setup_profile`, `primary_setup_profile`, `normalize_machine_type`, `resolve_machine_type`, `machine_is_laptop`, `resolve_default_agent`
 - Cooldown stamps: `record_system_upgrade_stamps`, `system_upgrade_cooldown_expired`
 - Fonts: `refresh_font_cache`
 
@@ -125,8 +125,10 @@ Config reads/writes go through `load_bootstrap_config` / `write_bootstrap_config
 Stored at `~/.config/dotfiles-arch/.dotfiles_bootstrap_config`:
 
 - `FULL_NAME`, `EMAIL_ADDRESS`, `SETUP_PROFILES` (space-separated multi-select),
-  `SETUP_PROFILE` (primary for older readers), `INSTALL_NVIDIA`, `MACHINE_TYPE`,
-  `DEFAULT_AGENT` (`cursor`|`claude`, resolved by `setup-code.sh` — see below)
+  `SETUP_PROFILE` (primary for older readers), `MACHINE_TYPE`,
+  `DEFAULT_AGENT` (`cursor`|`claude`, resolved by `setup-code.sh` — see below).
+  NVIDIA driver install is not a saved setting; it's a `dfa` catalog item
+  gated on the "NVIDIA GPU detected" Capability (see `setup-nvidia.sh` below).
 
 `bootstrap.sh` / `sync.sh` export `MACHINE_TYPE` for the setup scripts; `setup-gnome.sh` also falls back to `load_bootstrap_config` + `has_battery`.
 
@@ -149,7 +151,7 @@ Shared: Kitty, tmux, Claude Code, Neovim, languages, Docker, Spotify, Obsidian, 
 - **setup-node.sh / setup-claude.sh**: NVM at `~/.config/nvm` (checksummed install.sh, never `curl|bash`); Claude uses user-level `npm` (never `sudo npm`). `setup-claude.sh` also idempotently merges the `nvim-reveal-edit` `PostToolUse` hook into `~/.claude/settings.json` (jq, touching only `.hooks.PostToolUse`)
 - **setup-code.sh**: Installs `tmux`, `lazygit`, `lazydocker`; runs last in `run-profile-setup.sh` (after profile extras) so Cursor/Claude are already on PATH; resolves `DEFAULT_AGENT` via `resolve_default_agent` — auto-picks the one CLI installed, prompts (Enter keeps the saved choice) when both are, leaves it empty when neither is — and persists it with `write_bootstrap_config`
 - **setup-gnome.sh**: Only when `gnome-shell` is installed; power policy from `MACHINE_TYPE` (`power-profiles-daemon` profile, `/etc/systemd/logind.conf.d/dotfiles-arch-lid.conf` — laptop suspends on battery lid-close but ignores lid on AC/docked, `90-dotfiles-arch-usb-wakeup.rules` for KVM HID wake, audio powersave), falling back to `has_battery`; installs/configures Dash to Panel (always-visible full-width top bar, small centered icons, every monitor); Pop Shell auto-tiling off by default
-- **setup-nvidia.sh**: Installs `nvidia-open-dkms` only when `INSTALL_NVIDIA=true`; never swaps an existing driver flavor; persists via `write_bootstrap_config`
+- **setup-nvidia.sh**: `--install`/`--uninstall <packages...>` is the dfa Catalog Engine's System Adapter path for the `nvidia` catalog item (`dfa/catalog/items/nvidia.toml`, gated on the "nvidia-gpu" Capability, detected via `system.HasNVIDIAHardware` mirroring `has_nvidia_hardware`); direct invocation (`run-profile-setup.sh --yes`) auto-installs `nvidia-open-dkms` only when NVIDIA hardware/packages are detected — no saved preference, no prompt. Never swaps an existing driver flavor.
 - **setup-fonts.sh**: Adwaita + Noto + Liberation + Nerd Fonts; GNOME UI uses Adwaita Sans / JetBrainsMono NF
 - **setup-cursor.sh**: work-profile-only (see Profiles table); IDE via AUR (`cursor-bin`); Agent CLI via AUR (`cursor-cli`), which ships only `/usr/bin/cursor-agent` — the script adds an `agent` compat symlink and clears any older `curl | bash` install from `~/.local/share/cursor-agent`. On machines with no NVIDIA hardware (integrated-GPU-only; checked via `has_nvidia_hardware` PCI detection, not driver packages), it also drops a `~/.local/share/applications/cursor.desktop` override that adds `--ozone-platform=x11` and idempotently forces `disable-hardware-acceleration: true` in `~/.cursor/argv.json` (JSONC — comments preserved, not a jq rewrite), working around an Electron native-Wayland hang-on-quit/slowness bug; both are removed/left alone automatically if NVIDIA hardware is later detected. It also idempotently merges the `nvim-reveal-edit` `afterFileEdit` hook into `~/.cursor/hooks.json` (jq, touching only `.hooks.afterFileEdit` — this file is plain JSON, unlike JSONC `argv.json`)
 - **setup-devcontainer.sh**: Host-only platform devcontainer prerequisites (Docker/`gh` already shared); the Cursor Dev Containers extension step warns and skips if Cursor isn't installed (i.e. devcontainer profile without work)

--- a/NOTES.md
+++ b/NOTES.md
@@ -108,8 +108,8 @@ You can unmount via `umount /mnt/usb`
 After install, NVIDIA packages are **not** forced:
 
 - `post_install.sh` / `scripts/setup-nvidia.sh` detect existing NVIDIA packages (from archinstall) and/or an NVIDIA GPU
-- You are prompted; the choice is saved as `INSTALL_NVIDIA` in `~/.config/dotfiles-arch/.dotfiles_bootstrap_config`
-- Bootstrap and sync reuse that preference (`false` skips installing nvidia-open-dkms)
+- No preference is asked or saved — `nvidia-open-dkms` installs automatically when hardware/packages are detected, and skips otherwise
+- The `dfa` TUI also exposes NVIDIA driver install/uninstall as an ordinary catalog item, gated on the "NVIDIA GPU detected" capability
 
 ## After install
 

--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -168,7 +168,7 @@ skipped with a warning if Cursor isn't installed.
 
 | Package | Script | Purpose |
 |---------|--------|---------|
-| `nvidia-open-dkms`, `nvidia-utils`, `nvidia-settings`, `linux-headers` | `setup-nvidia.sh` | NVIDIA drivers, installed only when `INSTALL_NVIDIA=true` |
+| `nvidia-open-dkms`, `nvidia-utils`, `nvidia-settings`, `linux-headers` | `setup-nvidia.sh` | NVIDIA drivers — auto-installed when NVIDIA hardware/packages are detected; also a `dfa` catalog item gated on the "NVIDIA GPU detected" capability |
 
 ## Build / AUR plumbing
 

--- a/README.md
+++ b/README.md
@@ -76,11 +76,13 @@ You will be prompted for:
 
 - Full name + email (git)
 - Profiles (multi-select): **work**, **personal**, and/or **devcontainer**
-- Whether to install NVIDIA (`nvidia-open-dkms`)
 - Machine type: **laptop** or **desktop** (defaults to battery detection)
 
 Config is saved at `~/.config/dotfiles-arch/.dotfiles_bootstrap_config`
-(`FULL_NAME`, `EMAIL_ADDRESS`, `SETUP_PROFILES`, `SETUP_PROFILE` primary, `INSTALL_NVIDIA`, `MACHINE_TYPE`).
+(`FULL_NAME`, `EMAIL_ADDRESS`, `SETUP_PROFILES`, `SETUP_PROFILE` primary, `MACHINE_TYPE`).
+NVIDIA driver install (`nvidia-open-dkms`) is no longer a saved preference — it
+auto-installs when hardware/packages are detected, and is also an ordinary
+`dfa` catalog item gated on the "NVIDIA GPU detected" capability.
 
 Bootstrap then: updates pacman/yay → runs all setup scripts → configures GNOME (if present) → symlinks dotfiles.
 
@@ -183,7 +185,7 @@ On AC with the lid closed, the laptop stays awake; keyboard/mouse on a KVM can a
 
 ### NVIDIA
 
-Only when `INSTALL_NVIDIA=true`. Prefers **`nvidia-open-dkms`**; does not swap an already-installed driver flavor. See [NOTES.md](NOTES.md).
+Installed automatically only when NVIDIA hardware/packages are detected — no saved preference. Prefers **`nvidia-open-dkms`**; does not swap an already-installed driver flavor. Also available as an ordinary `dfa` catalog item, gated on the "NVIDIA GPU detected" capability. See [NOTES.md](NOTES.md).
 
 ---
 

--- a/dfa/catalog/items/nvidia.toml
+++ b/dfa/catalog/items/nvidia.toml
@@ -1,0 +1,12 @@
+id = "nvidia"
+name = "NVIDIA driver"
+description = "Open-source NVIDIA DKMS driver stack (nvidia-open-dkms + utils)."
+categories = ["hardware"]
+tier = "optional"
+capabilities = ["nvidia-gpu"]
+dependencies = []
+setup_script = "setup-nvidia.sh"
+
+[packages]
+pacman = ["nvidia-open-dkms", "nvidia-utils", "nvidia-settings", "linux-headers"]
+aur = []

--- a/dfa/internal/catalog/catalog.go
+++ b/dfa/internal/catalog/catalog.go
@@ -117,6 +117,55 @@ func (m Manifest) dependents(id string) []string {
 	return out
 }
 
+// CapabilityStatus is a detected machine fact about one named Capability
+// (e.g. "nvidia-gpu"): whether it's currently met, and — when it isn't — the
+// plain-language reason to show the user in place of the gated item's
+// controls.
+type CapabilityStatus struct {
+	Met    bool
+	Reason string
+}
+
+// Capabilities maps a Capability name (as referenced by Item.Capabilities)
+// to its currently detected status on this machine. It is plain data — the
+// System Adapter does the actual detection (lspci/sysfs probes, cached
+// user-declared answers) and builds this map; the Catalog Engine only
+// evaluates against it.
+type Capabilities map[string]CapabilityStatus
+
+// CapabilityGap names one capability a Software Item requires that isn't
+// currently met, plus the plain-language reason to show the user.
+type CapabilityGap struct {
+	Name   string
+	Reason string
+}
+
+const unmetCapabilityDefaultReason = "not available on this machine"
+
+// Gaps returns the capabilities item requires that aren't met by caps, in
+// the item's declared order — nil if the item has no requirements or every
+// requirement is met.
+func Gaps(item Item, caps Capabilities) []CapabilityGap {
+	var out []CapabilityGap
+	for _, name := range item.Capabilities {
+		status, ok := caps[name]
+		if ok && status.Met {
+			continue
+		}
+		reason := unmetCapabilityDefaultReason
+		if ok {
+			reason = status.Reason
+		}
+		out = append(out, CapabilityGap{Name: name, Reason: reason})
+	}
+	return out
+}
+
+// Available reports whether every capability item requires is met.
+func Available(item Item, caps Capabilities) bool {
+	return len(Gaps(item, caps)) == 0
+}
+
 // Selection is the set of currently-selected item ids.
 type Selection map[string]bool
 
@@ -137,6 +186,11 @@ var ErrUnknownItem = errors.New("catalog: unknown item id")
 // Core item. The Catalog Engine refuses such plans outright.
 var ErrCoreItemUninstall = errors.New("catalog: cannot uninstall a core item")
 
+// ErrCapabilityNotMet is returned when a requested selection targets an item
+// (or, via dependency resolution, pulls in an item) whose Capability
+// requirements aren't met.
+var ErrCapabilityNotMet = errors.New("catalog: capability requirement not met")
+
 // Plan is the result of applying a selection change: the resulting
 // selection, plus the concrete install/uninstall work and any side effects
 // (auto-selected dependencies, cascade-deselected dependents) that
@@ -151,6 +205,10 @@ type Plan struct {
 	// selected rather than refusing the whole plan over, so callers can
 	// surface why not everything in the category came out.
 	CoreItemsSkipped []string
+	// CapabilityBlocked lists items a SelectCategory call left unselected
+	// because their Capability requirements aren't met, rather than
+	// refusing the whole plan over them.
+	CapabilityBlocked []string
 }
 
 func sortedKeys(m map[string]bool) []string {
@@ -189,8 +247,10 @@ func Diff(current, desired Selection) Plan {
 }
 
 // Select adds itemID to the selection, transitively auto-selecting any
-// declared dependencies that aren't already selected.
-func Select(manifest Manifest, current Selection, itemID string) (Plan, error) {
+// declared dependencies that aren't already selected. It refuses (returning
+// ErrCapabilityNotMet) if itemID — or any dependency the resolution would
+// also select — has an unmet Capability requirement.
+func Select(manifest Manifest, current Selection, itemID string, caps Capabilities) (Plan, error) {
 	if _, ok := manifest.Item(itemID); !ok {
 		return Plan{}, fmt.Errorf("%w: %s", ErrUnknownItem, itemID)
 	}
@@ -198,19 +258,27 @@ func Select(manifest Manifest, current Selection, itemID string) (Plan, error) {
 	desired := current.Clone()
 	var autoSelected []string
 
-	var visit func(id string, isRoot bool)
-	visit = func(id string, isRoot bool) {
+	var visit func(id string, isRoot bool) error
+	visit = func(id string, isRoot bool) error {
+		it := manifest.byID[id]
+		if !Available(it, caps) {
+			return fmt.Errorf("%w: %s", ErrCapabilityNotMet, id)
+		}
 		alreadySelected := desired[id]
 		desired[id] = true
 		if !alreadySelected && !isRoot {
 			autoSelected = append(autoSelected, id)
 		}
-		it := manifest.byID[id]
 		for _, dep := range it.Dependencies {
-			visit(dep, false)
+			if err := visit(dep, false); err != nil {
+				return err
+			}
 		}
+		return nil
 	}
-	visit(itemID, true)
+	if err := visit(itemID, true); err != nil {
+		return Plan{}, err
+	}
 
 	plan := Diff(current, desired)
 	plan.AutoSelected = autoSelected
@@ -263,21 +331,32 @@ func Deselect(manifest Manifest, current Selection, itemID string) (Plan, error)
 }
 
 // SelectCategory selects every item in the given category (plus their
-// transitive dependencies).
-func SelectCategory(manifest Manifest, current Selection, category string) (Plan, error) {
+// transitive dependencies). An item whose Capability requirements aren't met
+// is left unselected rather than failing the whole call — it's reported via
+// Plan.CapabilityBlocked instead.
+func SelectCategory(manifest Manifest, current Selection, category string, caps Capabilities) (Plan, error) {
 	desired := current.Clone()
 	var autoSelected []string
+	var capBlocked []string
 	seen := map[string]bool{}
+	seenBlocked := map[string]bool{}
 
 	var visit func(id string, isRoot bool)
 	visit = func(id string, isRoot bool) {
+		it := manifest.byID[id]
+		if !Available(it, caps) {
+			if isRoot && !seenBlocked[id] {
+				capBlocked = append(capBlocked, id)
+				seenBlocked[id] = true
+			}
+			return
+		}
 		alreadySelected := desired[id]
 		desired[id] = true
 		if !alreadySelected && !isRoot && !seen[id] {
 			autoSelected = append(autoSelected, id)
 			seen[id] = true
 		}
-		it := manifest.byID[id]
 		for _, dep := range it.Dependencies {
 			visit(dep, false)
 		}
@@ -293,6 +372,7 @@ func SelectCategory(manifest Manifest, current Selection, category string) (Plan
 
 	plan := Diff(current, desired)
 	plan.AutoSelected = autoSelected
+	plan.CapabilityBlocked = capBlocked
 	return plan, nil
 }
 

--- a/dfa/internal/catalog/catalog_test.go
+++ b/dfa/internal/catalog/catalog_test.go
@@ -53,7 +53,7 @@ func TestSelect_AutoSelectsDependency(t *testing.T) {
 	m := fixtureManifest(t)
 	current := Selection{"git": true}
 
-	plan, err := Select(m, current, "git-delta")
+	plan, err := Select(m, current, "git-delta", nil)
 	if err != nil {
 		t.Fatalf("Select() error = %v", err)
 	}
@@ -73,7 +73,7 @@ func TestSelect_AutoSelectsMissingDependencyAndReportsIt(t *testing.T) {
 	m := fixtureManifest(t)
 	current := Selection{}
 
-	plan, err := Select(m, current, "git-delta")
+	plan, err := Select(m, current, "git-delta", nil)
 	if err != nil {
 		t.Fatalf("Select() error = %v", err)
 	}
@@ -92,7 +92,7 @@ func TestSelect_AutoSelectsMissingDependencyAndReportsIt(t *testing.T) {
 
 func TestSelect_UnknownItem(t *testing.T) {
 	m := fixtureManifest(t)
-	_, err := Select(m, Selection{}, "does-not-exist")
+	_, err := Select(m, Selection{}, "does-not-exist", nil)
 	if !errors.Is(err, ErrUnknownItem) {
 		t.Errorf("err = %v, want ErrUnknownItem", err)
 	}
@@ -152,7 +152,7 @@ func TestDeselect_RefusesWhenCascadeWouldHitCoreItem(t *testing.T) {
 func TestSelectCategory_SelectsEveryItemAndDeps(t *testing.T) {
 	m := fixtureManifest(t)
 
-	plan, err := SelectCategory(m, Selection{}, "essentials")
+	plan, err := SelectCategory(m, Selection{}, "essentials", nil)
 	if err != nil {
 		t.Fatalf("SelectCategory() error = %v", err)
 	}
@@ -169,7 +169,7 @@ func TestSelectCategory_SelectsEveryItemAndDeps(t *testing.T) {
 
 func TestSelectCategory_UnknownCategory(t *testing.T) {
 	m := fixtureManifest(t)
-	_, err := SelectCategory(m, Selection{}, "does-not-exist")
+	_, err := SelectCategory(m, Selection{}, "does-not-exist", nil)
 	if err == nil {
 		t.Fatal("expected error for unknown category, got nil")
 	}
@@ -203,6 +203,106 @@ func TestDiff_ComputesInstallAndUninstall(t *testing.T) {
 	}
 	if want := []string{"a"}; !reflect.DeepEqual(plan.ToUninstall, want) {
 		t.Errorf("ToUninstall = %v, want %v", plan.ToUninstall, want)
+	}
+}
+
+func TestGaps_NoRequirementsIsAlwaysAvailable(t *testing.T) {
+	m := fixtureManifest(t)
+	git, _ := m.Item("git")
+	if gaps := Gaps(git, nil); gaps != nil {
+		t.Errorf("Gaps() = %v, want nil for an item with no capability requirements", gaps)
+	}
+	if !Available(git, nil) {
+		t.Error("Available() = false, want true for an item with no capability requirements")
+	}
+}
+
+func TestGaps_ReportsUnmetCapabilityWithReason(t *testing.T) {
+	m := fixtureManifest(t)
+	nvidia, _ := m.Item("nvidia")
+	caps := Capabilities{"nvidia-gpu": {Met: false, Reason: "No NVIDIA GPU detected on this machine"}}
+
+	gaps := Gaps(nvidia, caps)
+	want := []CapabilityGap{{Name: "nvidia-gpu", Reason: "No NVIDIA GPU detected on this machine"}}
+	if !reflect.DeepEqual(gaps, want) {
+		t.Errorf("Gaps() = %v, want %v", gaps, want)
+	}
+	if Available(nvidia, caps) {
+		t.Error("Available() = true, want false (capability not met)")
+	}
+}
+
+func TestGaps_MissingCapabilityEntryUsesDefaultReason(t *testing.T) {
+	m := fixtureManifest(t)
+	nvidia, _ := m.Item("nvidia")
+
+	gaps := Gaps(nvidia, Capabilities{})
+	if len(gaps) != 1 || gaps[0].Name != "nvidia-gpu" || gaps[0].Reason == "" {
+		t.Errorf("Gaps() = %v, want one gap for nvidia-gpu with a non-empty default reason", gaps)
+	}
+}
+
+func TestAvailable_MetCapabilityAllowsItem(t *testing.T) {
+	m := fixtureManifest(t)
+	nvidia, _ := m.Item("nvidia")
+	caps := Capabilities{"nvidia-gpu": {Met: true}}
+
+	if !Available(nvidia, caps) {
+		t.Error("Available() = false, want true when the required capability is met")
+	}
+}
+
+func TestSelect_RefusesWhenCapabilityNotMet(t *testing.T) {
+	m := fixtureManifest(t)
+	caps := Capabilities{"nvidia-gpu": {Met: false, Reason: "no GPU"}}
+
+	_, err := Select(m, Selection{}, "nvidia", caps)
+	if !errors.Is(err, ErrCapabilityNotMet) {
+		t.Errorf("err = %v, want ErrCapabilityNotMet", err)
+	}
+}
+
+func TestSelect_AllowsWhenCapabilityMet(t *testing.T) {
+	m := fixtureManifest(t)
+	caps := Capabilities{"nvidia-gpu": {Met: true}}
+
+	plan, err := Select(m, Selection{}, "nvidia", caps)
+	if err != nil {
+		t.Fatalf("Select() error = %v", err)
+	}
+	if !plan.Selection["nvidia"] {
+		t.Errorf("Selection = %v, want nvidia selected", plan.Selection)
+	}
+}
+
+func TestSelectCategory_SkipsCapabilityBlockedItemsAndReportsThem(t *testing.T) {
+	m := fixtureManifest(t)
+
+	plan, err := SelectCategory(m, Selection{}, "hardware", Capabilities{})
+	if err != nil {
+		t.Fatalf("SelectCategory() error = %v", err)
+	}
+	if plan.Selection["nvidia"] {
+		t.Errorf("Selection[nvidia] = true, want false (capability not met)")
+	}
+	want := []string{"nvidia"}
+	if !reflect.DeepEqual(plan.CapabilityBlocked, want) {
+		t.Errorf("CapabilityBlocked = %v, want %v", plan.CapabilityBlocked, want)
+	}
+}
+
+func TestSelectCategory_IncludesCapabilityMetItems(t *testing.T) {
+	m := fixtureManifest(t)
+
+	plan, err := SelectCategory(m, Selection{}, "hardware", Capabilities{"nvidia-gpu": {Met: true}})
+	if err != nil {
+		t.Fatalf("SelectCategory() error = %v", err)
+	}
+	if !plan.Selection["nvidia"] {
+		t.Errorf("Selection[nvidia] = false, want true (capability met)")
+	}
+	if plan.CapabilityBlocked != nil {
+		t.Errorf("CapabilityBlocked = %v, want nil", plan.CapabilityBlocked)
 	}
 }
 

--- a/dfa/internal/dashboard/dashboard.go
+++ b/dfa/internal/dashboard/dashboard.go
@@ -27,6 +27,24 @@ const installSoftwareTitle = "Install/Uninstall Software"
 // screen exposes so far — later tickets grow the rest of the taxonomy.
 const essentialsCategory = "essentials"
 
+// nvidiaGPUCapability is the Capability name the "nvidia" catalog item
+// (dfa/catalog/items/nvidia.toml) is gated on.
+const nvidiaGPUCapability = "nvidia-gpu"
+
+// detectCapabilities builds the machine facts the Catalog Engine evaluates
+// capability-gated items against (see catalog.Gaps/Available), probing
+// hardware through the System Adapter.
+func detectCapabilities() catalog.Capabilities {
+	met := system.HasNVIDIAHardware()
+	reason := ""
+	if !met {
+		reason = "No NVIDIA GPU detected on this machine"
+	}
+	return catalog.Capabilities{
+		nvidiaGPUCapability: {Met: met, Reason: reason},
+	}
+}
+
 // screenItem is one row in the dashboard list: a planned dfa screen.
 type screenItem struct {
 	title       string
@@ -193,7 +211,7 @@ func (m *Model) enterSoftwareScreen() {
 	}
 
 	runner := software.ScriptsDirRunner{ScriptsDir: filepath.Join(m.repoRoot, "scripts")}
-	sm := software.New(m.manifest, essentialsCategory, selection, runner)
+	sm := software.New(m.manifest, essentialsCategory, selection, runner, detectCapabilities())
 	m.software = &sm
 }
 

--- a/dfa/internal/software/software.go
+++ b/dfa/internal/software/software.go
@@ -40,35 +40,42 @@ func (r ScriptsDirRunner) RunScript(scriptName string, args ...string) (system.R
 }
 
 var (
-	titleStyle = lipgloss.NewStyle().Bold(true).Padding(0, 1)
-	helpStyle  = lipgloss.NewStyle().Faint(true).Padding(1, 1, 0, 1)
-	lockStyle  = lipgloss.NewStyle().Faint(true)
-	errStyle   = lipgloss.NewStyle().Padding(0, 1)
-	cursorSign = "> "
-	noCursor   = "  "
+	titleStyle    = lipgloss.NewStyle().Bold(true).Padding(0, 1)
+	helpStyle     = lipgloss.NewStyle().Faint(true).Padding(1, 1, 0, 1)
+	lockStyle     = lipgloss.NewStyle().Faint(true)
+	disabledStyle = lipgloss.NewStyle().Faint(true).Italic(true)
+	errStyle      = lipgloss.NewStyle().Padding(0, 1)
+	cursorSign    = "> "
+	noCursor      = "  "
 )
 
 // Model is the Bubble Tea model for one category's Install/Uninstall
 // Software screen.
 type Model struct {
-	manifest  catalog.Manifest
-	category  string
-	items     []catalog.Item
-	selection catalog.Selection
-	runner    ScriptRunner
-	cursor    int
-	statusMsg string
+	manifest     catalog.Manifest
+	category     string
+	items        []catalog.Item
+	selection    catalog.Selection
+	capabilities catalog.Capabilities
+	runner       ScriptRunner
+	cursor       int
+	statusMsg    string
 }
 
 // New builds a software Model scoped to one category, starting from the
 // given selection (e.g. derived from querying what's currently installed).
-func New(manifest catalog.Manifest, category string, selection catalog.Selection, runner ScriptRunner) Model {
+// capabilities is the machine facts a capability-gated item's requirements
+// are checked against (see catalog.Gaps/Available) — an item whose
+// requirements aren't met is shown disabled, with the reason, and can't be
+// selected.
+func New(manifest catalog.Manifest, category string, selection catalog.Selection, runner ScriptRunner, capabilities catalog.Capabilities) Model {
 	return Model{
-		manifest:  manifest,
-		category:  category,
-		items:     manifest.ItemsByCategory(category),
-		selection: selection.Clone(),
-		runner:    runner,
+		manifest:     manifest,
+		category:     category,
+		items:        manifest.ItemsByCategory(category),
+		selection:    selection.Clone(),
+		capabilities: capabilities,
+		runner:       runner,
 	}
 }
 
@@ -120,18 +127,41 @@ func (m *Model) toggleCurrent() {
 	}
 	item := m.items[m.cursor]
 
+	if !m.selection[item.ID] {
+		if gaps := catalog.Gaps(item, m.capabilities); len(gaps) > 0 {
+			m.statusMsg = capabilityUnavailableMessage(item, gaps)
+			return
+		}
+	}
+
 	var plan catalog.Plan
 	var err error
 	if m.selection[item.ID] {
 		plan, err = catalog.Deselect(m.manifest, m.selection, item.ID)
 	} else {
-		plan, err = catalog.Select(m.manifest, m.selection, item.ID)
+		plan, err = catalog.Select(m.manifest, m.selection, item.ID, m.capabilities)
 	}
 	m.applyPlanOrError(plan, err)
 }
 
+// capabilityUnavailableMessage renders the status-bar explanation for why a
+// capability-gated item's toggle key press was ignored.
+func capabilityUnavailableMessage(item catalog.Item, gaps []catalog.CapabilityGap) string {
+	return fmt.Sprintf("%s is unavailable: %s", item.Name, joinGapReasons(gaps))
+}
+
+// joinGapReasons renders a list of CapabilityGaps as one semicolon-separated
+// reason string, shared by the status-bar message and the disabled row label.
+func joinGapReasons(gaps []catalog.CapabilityGap) string {
+	reasons := make([]string, len(gaps))
+	for i, g := range gaps {
+		reasons[i] = g.Reason
+	}
+	return strings.Join(reasons, "; ")
+}
+
 func (m *Model) selectAll() {
-	plan, err := catalog.SelectCategory(m.manifest, m.selection, m.category)
+	plan, err := catalog.SelectCategory(m.manifest, m.selection, m.category, m.capabilities)
 	m.applyPlanOrError(plan, err)
 }
 
@@ -188,11 +218,19 @@ func (m *Model) runPlan(plan catalog.Plan) {
 	m.statusMsg = summarizePlan(plan)
 	if len(plan.CoreItemsSkipped) > 0 {
 		skipped := "left alone (core, locked): " + strings.Join(plan.CoreItemsSkipped, ", ")
-		if m.statusMsg == "" {
-			m.statusMsg = skipped
-		} else {
-			m.statusMsg += " • " + skipped
-		}
+		m.appendStatus(skipped)
+	}
+	if len(plan.CapabilityBlocked) > 0 {
+		blocked := "unavailable (capability not met): " + strings.Join(plan.CapabilityBlocked, ", ")
+		m.appendStatus(blocked)
+	}
+}
+
+func (m *Model) appendStatus(msg string) {
+	if m.statusMsg == "" {
+		m.statusMsg = msg
+	} else {
+		m.statusMsg += " • " + msg
 	}
 }
 
@@ -226,7 +264,9 @@ func (m Model) View() string {
 			checkbox = "[x]"
 		}
 		line := fmt.Sprintf("%s%s %s — %s", cursor, checkbox, item.Name, item.Description)
-		if item.Tier == catalog.TierCore {
+		if gaps := catalog.Gaps(item, m.capabilities); len(gaps) > 0 {
+			line = disabledStyle.Render(line + " (unavailable: " + joinGapReasons(gaps) + ")")
+		} else if item.Tier == catalog.TierCore {
 			line = lockStyle.Render(line + " (core, locked)")
 		}
 		b.WriteString(line)

--- a/dfa/internal/software/software_test.go
+++ b/dfa/internal/software/software_test.go
@@ -55,6 +55,12 @@ func fixtureManifest(t *testing.T) catalog.Manifest {
 			SetupScript: "setup-essentials.sh",
 			Packages:    catalog.Packages{Pacman: []string{"starship"}},
 		},
+		{
+			ID: "nvidia", Name: "nvidia", Description: "NVIDIA driver",
+			Categories: []string{"hardware"}, Tier: catalog.TierOptional,
+			Capabilities: []string{"nvidia-gpu"}, SetupScript: "setup-nvidia.sh",
+			Packages: catalog.Packages{Pacman: []string{"nvidia-open-dkms"}},
+		},
 	})
 	if err != nil {
 		t.Fatalf("NewManifest() error = %v", err)
@@ -76,7 +82,7 @@ func keyMsg(s string) tea.KeyMsg {
 }
 
 func TestNew_StartsWithNoSelectionByDefault(t *testing.T) {
-	m := New(fixtureManifest(t), "essentials", catalog.Selection{}, &fakeRunner{})
+	m := New(fixtureManifest(t), "essentials", catalog.Selection{}, &fakeRunner{}, nil)
 	if len(m.items) != 3 {
 		t.Fatalf("len(items) = %d, want 3", len(m.items))
 	}
@@ -87,7 +93,7 @@ func TestNew_StartsWithNoSelectionByDefault(t *testing.T) {
 
 func TestUpdate_SpaceSelectsItemAndRunsInstall(t *testing.T) {
 	runner := &fakeRunner{}
-	m := New(fixtureManifest(t), "essentials", catalog.Selection{}, runner)
+	m := New(fixtureManifest(t), "essentials", catalog.Selection{}, runner, nil)
 	m.cursor = 1 // git-delta
 
 	updated, _ := m.Update(keyMsg(" "))
@@ -109,7 +115,7 @@ func TestUpdate_SpaceSelectsItemAndRunsInstall(t *testing.T) {
 func TestUpdate_SpaceTogglesBackToDeselectAndRunsUninstall(t *testing.T) {
 	runner := &fakeRunner{}
 	current := catalog.Selection{"git": true, "starship": true}
-	m := New(fixtureManifest(t), "essentials", current, runner)
+	m := New(fixtureManifest(t), "essentials", current, runner, nil)
 	m.cursor = 2 // starship
 
 	updated, _ := m.Update(keyMsg(" "))
@@ -129,7 +135,7 @@ func TestUpdate_SpaceTogglesBackToDeselectAndRunsUninstall(t *testing.T) {
 func TestUpdate_SpaceOnCoreItemRefusesAndShowsError(t *testing.T) {
 	runner := &fakeRunner{}
 	current := catalog.Selection{"git": true}
-	m := New(fixtureManifest(t), "essentials", current, runner)
+	m := New(fixtureManifest(t), "essentials", current, runner, nil)
 	m.cursor = 0 // git (core)
 
 	updated, _ := m.Update(keyMsg(" "))
@@ -148,7 +154,7 @@ func TestUpdate_SpaceOnCoreItemRefusesAndShowsError(t *testing.T) {
 
 func TestUpdate_SelectAllInCategory(t *testing.T) {
 	runner := &fakeRunner{}
-	m := New(fixtureManifest(t), "essentials", catalog.Selection{}, runner)
+	m := New(fixtureManifest(t), "essentials", catalog.Selection{}, runner, nil)
 
 	updated, _ := m.Update(keyMsg("a"))
 	m = updated.(Model)
@@ -166,7 +172,7 @@ func TestUpdate_SelectAllInCategory(t *testing.T) {
 func TestUpdate_DeselectAllInCategoryLeavesCoreItems(t *testing.T) {
 	runner := &fakeRunner{}
 	current := catalog.Selection{"git": true, "git-delta": true, "starship": true}
-	m := New(fixtureManifest(t), "essentials", current, runner)
+	m := New(fixtureManifest(t), "essentials", current, runner, nil)
 
 	updated, _ := m.Update(keyMsg("u"))
 	m = updated.(Model)
@@ -188,7 +194,7 @@ func TestUpdate_DeselectAllInCategoryLeavesCoreItems(t *testing.T) {
 
 func TestUpdate_FailedInstallDoesNotMarkItemSelected(t *testing.T) {
 	runner := &fakeRunner{err: errBoom}
-	m := New(fixtureManifest(t), "essentials", catalog.Selection{"git": true}, runner)
+	m := New(fixtureManifest(t), "essentials", catalog.Selection{"git": true}, runner, nil)
 	m.cursor = 2 // starship
 
 	updated, _ := m.Update(keyMsg(" "))
@@ -205,7 +211,7 @@ func TestUpdate_FailedInstallDoesNotMarkItemSelected(t *testing.T) {
 func TestUpdate_FailedUninstallLeavesItemSelected(t *testing.T) {
 	runner := &fakeRunner{err: errBoom}
 	current := catalog.Selection{"git": true, "starship": true}
-	m := New(fixtureManifest(t), "essentials", current, runner)
+	m := New(fixtureManifest(t), "essentials", current, runner, nil)
 	m.cursor = 2 // starship
 
 	updated, _ := m.Update(keyMsg(" "))
@@ -219,7 +225,7 @@ func TestUpdate_FailedUninstallLeavesItemSelected(t *testing.T) {
 func TestUpdate_DeselectAllReportsCoreItemsLeftAlone(t *testing.T) {
 	runner := &fakeRunner{}
 	current := catalog.Selection{"git": true, "starship": true}
-	m := New(fixtureManifest(t), "essentials", current, runner)
+	m := New(fixtureManifest(t), "essentials", current, runner, nil)
 
 	updated, _ := m.Update(keyMsg("u"))
 	m = updated.(Model)
@@ -230,7 +236,7 @@ func TestUpdate_DeselectAllReportsCoreItemsLeftAlone(t *testing.T) {
 }
 
 func TestUpdate_CursorMovesWithinBounds(t *testing.T) {
-	m := New(fixtureManifest(t), "essentials", catalog.Selection{}, &fakeRunner{})
+	m := New(fixtureManifest(t), "essentials", catalog.Selection{}, &fakeRunner{}, nil)
 
 	updated, _ := m.Update(keyMsg("up"))
 	m = updated.(Model)
@@ -247,8 +253,54 @@ func TestUpdate_CursorMovesWithinBounds(t *testing.T) {
 	}
 }
 
+func TestUpdate_SpaceOnCapabilityBlockedItemRefusesAndShowsReason(t *testing.T) {
+	runner := &fakeRunner{}
+	caps := catalog.Capabilities{"nvidia-gpu": {Met: false, Reason: "No NVIDIA GPU detected on this machine"}}
+	m := New(fixtureManifest(t), "hardware", catalog.Selection{}, runner, caps)
+
+	updated, _ := m.Update(keyMsg(" "))
+	m = updated.(Model)
+
+	if m.selection["nvidia"] {
+		t.Errorf("selection[nvidia] = true, want false (capability not met)")
+	}
+	if !strings.Contains(m.statusMsg, "No NVIDIA GPU detected on this machine") {
+		t.Errorf("statusMsg = %q, want it to include the capability's reason", m.statusMsg)
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("calls = %+v, want no script invocations", runner.calls)
+	}
+}
+
+func TestUpdate_SpaceOnCapabilityMetItemInstalls(t *testing.T) {
+	runner := &fakeRunner{}
+	caps := catalog.Capabilities{"nvidia-gpu": {Met: true}}
+	m := New(fixtureManifest(t), "hardware", catalog.Selection{}, runner, caps)
+
+	updated, _ := m.Update(keyMsg(" "))
+	m = updated.(Model)
+
+	if !m.selection["nvidia"] {
+		t.Errorf("selection[nvidia] = false, want true (capability met)")
+	}
+	want := []scriptCall{{script: "setup-nvidia.sh", args: []string{"--install", "nvidia-open-dkms"}}}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Errorf("calls = %+v, want %+v", runner.calls, want)
+	}
+}
+
+func TestView_ShowsDisabledCapabilityGatedItemWithReason(t *testing.T) {
+	caps := catalog.Capabilities{"nvidia-gpu": {Met: false, Reason: "No NVIDIA GPU detected on this machine"}}
+	m := New(fixtureManifest(t), "hardware", catalog.Selection{}, &fakeRunner{}, caps)
+
+	view := m.View()
+	if !strings.Contains(view, "unavailable") || !strings.Contains(view, "No NVIDIA GPU detected on this machine") {
+		t.Errorf("View() = %q, want it to show the item disabled with its unmet-capability reason", view)
+	}
+}
+
 func TestUpdate_EscRequestsBack(t *testing.T) {
-	m := New(fixtureManifest(t), "essentials", catalog.Selection{}, &fakeRunner{})
+	m := New(fixtureManifest(t), "essentials", catalog.Selection{}, &fakeRunner{}, nil)
 
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	if cmd == nil {

--- a/dfa/internal/system/capabilities.go
+++ b/dfa/internal/system/capabilities.go
@@ -1,0 +1,46 @@
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// nvidiaLspciPattern mirrors fn-lib.sh's has_nvidia_hardware grep: an NVIDIA
+// VGA/3D/Display controller line from `lspci -nn`.
+var nvidiaLspciPattern = regexp.MustCompile(`(?i)nvidia.*(vga|3d|display)|(vga|3d|display).*nvidia`)
+
+// nvidiaPCIVendorID is the PCI vendor id for NVIDIA, as read from
+// /sys/bus/pci/devices/*/vendor.
+const nvidiaPCIVendorID = "0x10de"
+
+// containsNVIDIAController reports whether `lspci -nn` output names an
+// NVIDIA VGA/3D/Display controller. Split out from HasNVIDIAHardware so the
+// parsing logic is unit-testable without touching the real machine.
+func containsNVIDIAController(lspciOutput string) bool {
+	return nvidiaLspciPattern.MatchString(lspciOutput)
+}
+
+// HasNVIDIAHardware reports whether an NVIDIA GPU is visible on this
+// machine's PCI bus. This is a thin I/O wrapper (not unit tested directly,
+// per the Catalog Engine's testing decision) mirroring fn-lib.sh's
+// has_nvidia_hardware: prefer `lspci`, falling back to scanning sysfs PCI
+// vendor ids when lspci isn't on PATH.
+func HasNVIDIAHardware() bool {
+	if result, err := Run("lspci", "-nn"); err == nil && result.ExitCode == 0 {
+		return containsNVIDIAController(result.Stdout)
+	}
+
+	matches, _ := filepath.Glob("/sys/bus/pci/devices/*/vendor")
+	for _, path := range matches {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		if strings.TrimSpace(string(data)) == nvidiaPCIVendorID {
+			return true
+		}
+	}
+	return false
+}

--- a/dfa/internal/system/capabilities_test.go
+++ b/dfa/internal/system/capabilities_test.go
@@ -1,0 +1,40 @@
+package system
+
+import "testing"
+
+func TestContainsNVIDIAController(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name:   "nvidia VGA controller",
+			output: "01:00.0 VGA compatible controller [0300]: NVIDIA Corporation TU117M [GeForce GTX 1650 Mobile] [10de:1f91]",
+			want:   true,
+		},
+		{
+			name:   "nvidia 3D controller",
+			output: "01:00.0 3D controller [0302]: NVIDIA Corporation GA104M [GeForce RTX 3070 Mobile / Max-Q] [10de:249d]",
+			want:   true,
+		},
+		{
+			name:   "intel-only machine",
+			output: "00:02.0 VGA compatible controller [0300]: Intel Corporation TigerLake-LP GT2 [Iris Xe Graphics] [8086:9a49]",
+			want:   false,
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := containsNVIDIAController(tt.output); got != tt.want {
+				t.Errorf("containsNVIDIAController(%q) = %v, want %v", tt.output, got, tt.want)
+			}
+		})
+	}
+}

--- a/post_install.sh
+++ b/post_install.sh
@@ -2,7 +2,7 @@
 
 # Minimal post-install after archinstall:
 # - enable multilib
-# - optionally install NVIDIA drivers (detect / saved preference / prompt)
+# - install NVIDIA drivers when hardware/packages are detected
 # - install Kitty + base tooling
 #
 # Hands off directly into bootstrap.sh at the end (any args are forwarded),
@@ -56,15 +56,11 @@ fi
 # --------------------------
 # NVIDIA (conditional)
 # --------------------------
-# Use --yes when INSTALL_NVIDIA is already saved (re-runs); otherwise prompt.
+# setup-nvidia.sh auto-installs only when NVIDIA hardware/packages are
+# detected — no prompt, no saved preference.
 
 if [ -r "$SCRIPT_DIR/scripts/setup-nvidia.sh" ]; then
-  load_bootstrap_config 2>/dev/null || true
-  if [ "${INSTALL_NVIDIA:-}" = "true" ] || [ "${INSTALL_NVIDIA:-}" = "false" ]; then
-    bash "$SCRIPT_DIR/scripts/setup-nvidia.sh" --yes
-  else
-    bash "$SCRIPT_DIR/scripts/setup-nvidia.sh"
-  fi
+  bash "$SCRIPT_DIR/scripts/setup-nvidia.sh"
 else
   echo "Warning: scripts/setup-nvidia.sh not found; skipping NVIDIA setup"
 fi

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -145,7 +145,6 @@ if ! validate_bootstrap_profile; then
   exit 1
 fi
 
-resolve_nvidia_preference
 resolve_machine_type
 
 if [ "$ASSUME_YES" = false ]; then
@@ -154,7 +153,6 @@ if [ "$ASSUME_YES" = false ]; then
   echo "Full Name: $(fmt_choice "$FULL_NAME")"
   echo "Email Address: $(fmt_choice "$EMAIL_ADDRESS")"
   echo "Setup Profiles: $(fmt_choice "$(format_setup_profiles)")"
-  echo "Install NVIDIA: $(fmt_choice "$INSTALL_NVIDIA")"
   echo "Machine Type: $(fmt_choice "$MACHINE_TYPE")"
   read -rp "Is this information correct? [y/n] (Enter = $(fmt_choice "no")): " CONFIRMATION
   if [[ ! "${CONFIRMATION:-}" =~ ^[Yy]$ ]]; then
@@ -168,7 +166,7 @@ write_bootstrap_config
 print_line_break "Starting bootstrap"
 print_info_message "Display server: ${XDG_SESSION_TYPE:-unknown}"
 print_info_message "User: $(whoami)  Home: $USER_HOME_DIR"
-print_info_message "Profiles: $(format_setup_profiles)  INSTALL_NVIDIA: $INSTALL_NVIDIA  MACHINE_TYPE: $MACHINE_TYPE"
+print_info_message "Profiles: $(format_setup_profiles)  MACHINE_TYPE: $MACHINE_TYPE"
 
 sudo -v
 start_sudo_keepalive

--- a/scripts/fn-lib.sh
+++ b/scripts/fn-lib.sh
@@ -130,8 +130,7 @@ bootstrap_config_file() {
 KNOWN_SETUP_PROFILES=(work personal devcontainer)
 
 # Source saved bootstrap config if present
-# (FULL_NAME, EMAIL, SETUP_PROFILES, SETUP_PROFILE, INSTALL_NVIDIA, MACHINE_TYPE,
-# DEFAULT_AGENT).
+# (FULL_NAME, EMAIL, SETUP_PROFILES, SETUP_PROFILE, MACHINE_TYPE, DEFAULT_AGENT).
 load_bootstrap_config() {
   local f
   f="$(bootstrap_config_file)"
@@ -219,7 +218,7 @@ validate_bootstrap_profile() {
   return 0
 }
 
-# Write current identity/profile/NVIDIA/machine prefs (full rewrite of known keys).
+# Write current identity/profile/machine prefs (full rewrite of known keys).
 # Values are shell-escaped so a sourced config cannot inject code via quotes/$().
 # SETUP_PROFILES is canonical (space-separated multi-select); SETUP_PROFILE is primary (compat).
 write_bootstrap_config() {
@@ -239,7 +238,6 @@ write_bootstrap_config() {
     printf 'EMAIL_ADDRESS=%q\n' "${EMAIL_ADDRESS:-}"
     printf 'SETUP_PROFILES=%q\n' "${SETUP_PROFILES}"
     printf 'SETUP_PROFILE=%q\n' "${SETUP_PROFILE}"
-    printf 'INSTALL_NVIDIA=%q\n' "${INSTALL_NVIDIA:-false}"
     printf 'MACHINE_TYPE=%q\n' "${MACHINE_TYPE:-}"
     printf 'DEFAULT_AGENT=%q\n' "${DEFAULT_AGENT:-}"
   } >"$f"
@@ -365,62 +363,6 @@ machine_is_laptop() {
     laptop) return 0 ;;
     desktop) return 1 ;;
     *) has_battery ;;
-  esac
-}
-
-# Resolve INSTALL_NVIDIA from saved value / hardware / prompts.
-# Uses ASSUME_YES=true|false (default false). Sets INSTALL_NVIDIA to true|false.
-resolve_nvidia_preference() {
-  local assume_yes="${ASSUME_YES:-false}"
-  local nvidia_default="false"
-  local default_label nvidia_input
-
-  if [[ "${INSTALL_NVIDIA:-}" == "true" || "${INSTALL_NVIDIA:-}" == "false" ]]; then
-    if [[ "$assume_yes" == "true" ]]; then
-      return 0
-    fi
-    echo ""
-    print_info_message "Current INSTALL_NVIDIA: $(fmt_choice "$INSTALL_NVIDIA")"
-    read -rp "Press Enter to keep INSTALL_NVIDIA=$(fmt_choice "$INSTALL_NVIDIA"), or type true/false: " nvidia_input
-    case "${nvidia_input,,}" in
-      "") ;; # Enter → keep
-      true|y|yes) INSTALL_NVIDIA="true" ;;
-      false|n|no|0) INSTALL_NVIDIA="false" ;;
-      *)
-        print_warning_message "Unrecognized input '$nvidia_input'; keeping INSTALL_NVIDIA=$INSTALL_NVIDIA"
-        ;;
-    esac
-    return 0
-  fi
-
-  if has_nvidia_packages || has_nvidia_hardware; then
-    nvidia_default="true"
-  fi
-
-  if [[ "$assume_yes" == "true" ]]; then
-    INSTALL_NVIDIA="$nvidia_default"
-    print_info_message "INSTALL_NVIDIA not saved — auto-set to $INSTALL_NVIDIA (packages/hardware detect)"
-    return 0
-  fi
-
-  echo ""
-  print_info_message "NVIDIA drivers are optional (skip on AMD/Intel-only machines)."
-  if has_nvidia_packages; then
-    print_info_message "Detected: NVIDIA packages already installed (likely from archinstall)"
-  fi
-  if has_nvidia_hardware; then
-    print_info_message "Detected: NVIDIA GPU on PCI bus"
-  fi
-  if [[ "$nvidia_default" == "true" ]]; then
-    default_label="yes"
-  else
-    default_label="no"
-  fi
-  read -rp "Install/keep NVIDIA drivers on this machine? [y/n] (Enter = $(fmt_choice "$default_label")): " nvidia_input
-  nvidia_input="${nvidia_input:-$nvidia_default}"
-  case "${nvidia_input,,}" in
-    y|yes|true) INSTALL_NVIDIA="true" ;;
-    *) INSTALL_NVIDIA="false" ;;
   esac
 }
 
@@ -848,7 +790,7 @@ start_sudo_keepalive() {
 run_profile_setup_scripts() {
   local assume_yes="${1:-false}" rc
 
-  export SETUP_PROFILES SETUP_PROFILE FULL_NAME EMAIL_ADDRESS INSTALL_NVIDIA MACHINE_TYPE
+  export SETUP_PROFILES SETUP_PROFILE FULL_NAME EMAIL_ADDRESS MACHINE_TYPE
   export SETUP_CONTINUE_ON_ERROR=true
   if [[ "$assume_yes" == "true" ]]; then
     export DOTFILES_AUR_ASSUME_YES=true

--- a/scripts/setup-cursor.sh
+++ b/scripts/setup-cursor.sh
@@ -59,7 +59,7 @@ fi
 # in argv.json alone does not fix this). Forcing the Chromium/Electron ozone platform to
 # x11 (XWayland) works around it. Gated on actual PCI hardware (has_nvidia_hardware), not
 # installed driver packages — a machine can have nvidia-* packages left over from a prior
-# INSTALL_NVIDIA=true run with no NVIDIA GPU physically present. Skip entirely when NVIDIA
+# NVIDIA catalog-item install with no NVIDIA GPU physically present. Skip entirely when NVIDIA
 # hardware is present, where the default path is already exercised and known-good.
 CURSOR_SYSTEM_DESKTOP_FILE="/usr/share/applications/cursor.desktop"
 CURSOR_USER_APPLICATIONS_DIR="$USER_HOME_DIR/.local/share/applications"

--- a/scripts/setup-nvidia.sh
+++ b/scripts/setup-nvidia.sh
@@ -1,13 +1,21 @@
 #!/bin/bash
 # --------------------------
-# Setup NVIDIA drivers (optional)
+# Setup NVIDIA drivers
 # --------------------------
-# Installs nvidia-open-dkms + utils when this machine should use NVIDIA drivers.
+# Installs/removes the NVIDIA open DKMS driver stack. Two invocation modes:
 #
-# Decision order:
-#   1. INSTALL_NVIDIA=true|false from env / bootstrap config (explicit)
-#   2. --yes / non-interactive: install only if packages already present OR hardware detected
-#   3. Interactive: prompt, defaulting to yes when packages or hardware are detected
+#   --install / --uninstall <packages...>
+#     The dfa Catalog Engine's System Adapter path — the "nvidia" catalog
+#     item (dfa/catalog/items/nvidia.toml), gated on the "nvidia-gpu"
+#     Capability. Installs/removes exactly the given pacman packages via the
+#     shared ensure_pacman_pkgs/remove_pacman_pkgs helpers, the same
+#     convention as setup-essentials.sh. No preference is read or persisted
+#     here — the Catalog Engine only calls this when the capability is met
+#     (or when the user explicitly asks to uninstall).
+#
+#   Direct invocation (run-profile-setup.sh, always passed --yes):
+#     Auto-installs only when NVIDIA hardware or an existing NVIDIA package
+#     is detected on this machine. No prompt, no persisted preference.
 # --------------------------
 
 CURRENT_FILE_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
@@ -20,20 +28,18 @@ else
   exit 1
 fi
 
-ASSUME_YES=false
-FORCE_INSTALL=""
-for arg in "$@"; do
-  case "$arg" in
-    --yes|-y) ASSUME_YES=true ;;
-    --install) FORCE_INSTALL=true ;;
-    --skip) FORCE_INSTALL=false ;;
-  esac
-done
-
-# Load saved bootstrap preference when not already set
-if [ -z "${INSTALL_NVIDIA:-}" ]; then
-  load_bootstrap_config || true
-fi
+case "${1:-}" in
+  --install)
+    shift
+    ensure_pacman_pkgs "$@"
+    exit $?
+    ;;
+  --uninstall)
+    shift
+    remove_pacman_pkgs "$@"
+    exit $?
+    ;;
+esac
 
 print_tool_setup_start "NVIDIA drivers"
 
@@ -54,31 +60,8 @@ print_info_message "NVIDIA packages installed: $PACKAGES_PRESENT"
 print_info_message "NVIDIA driver module present: $DRIVER_PRESENT$([ "$DRIVER_PRESENT" = true ] && printf ' (%s)' "$(nvidia_driver_packages | paste -sd, -)")"
 print_info_message "NVIDIA hardware detected:  $HARDWARE_PRESENT"
 
-should_install=""
-if [ -n "$FORCE_INSTALL" ]; then
-  should_install="$FORCE_INSTALL"
-elif [[ "${INSTALL_NVIDIA:-}" == "true" || "${INSTALL_NVIDIA:-}" == "1" || "${INSTALL_NVIDIA:-}" == "yes" || "${INSTALL_NVIDIA:-}" == "y" ]]; then
-  should_install=true
-elif [[ "${INSTALL_NVIDIA:-}" == "false" || "${INSTALL_NVIDIA:-}" == "0" || "${INSTALL_NVIDIA:-}" == "no" || "${INSTALL_NVIDIA:-}" == "n" ]]; then
-  should_install=false
-fi
-
-if [ -z "$should_install" ]; then
-  # No explicit preference — detect / prompt (or auto with --yes)
-  export ASSUME_YES
-  resolve_nvidia_preference
-  should_install="$INSTALL_NVIDIA"
-fi
-
-# Persist preference for bootstrap/sync (preserve other identity fields)
-_nvidia_decision="$should_install"
-load_bootstrap_config || true
-INSTALL_NVIDIA="$_nvidia_decision"
-unset _nvidia_decision
-write_bootstrap_config
-
-if [ "$should_install" != true ]; then
-  print_info_message "Skipping NVIDIA driver install (INSTALL_NVIDIA=false)"
+if [ "$PACKAGES_PRESENT" != true ] && [ "$HARDWARE_PRESENT" != true ]; then
+  print_info_message "No NVIDIA hardware or packages detected — skipping NVIDIA driver install"
   print_tool_setup_complete "NVIDIA drivers"
   exit 0
 fi
@@ -86,13 +69,13 @@ fi
 # Never swap driver flavors (nvidia-open vs nvidia-open-dkms conflict).
 if [ "$DRIVER_PRESENT" = true ]; then
   print_info_message "NVIDIA kernel module already installed — leaving flavor alone, ensuring utils/settings/headers"
-  sudo pacman -S --needed --noconfirm nvidia-utils nvidia-settings linux-headers
+  ensure_pacman_pkgs nvidia-utils nvidia-settings linux-headers
 elif [ "$PACKAGES_PRESENT" = true ]; then
   print_info_message "NVIDIA utils present without a module package — installing nvidia-open-dkms"
-  sudo pacman -S --needed --noconfirm nvidia-open-dkms nvidia-utils nvidia-settings linux-headers
+  ensure_pacman_pkgs nvidia-open-dkms nvidia-utils nvidia-settings linux-headers
 else
   print_action_message "Installing NVIDIA open DKMS drivers (Turing+)"
-  sudo pacman -S --needed --noconfirm nvidia-open-dkms nvidia-utils nvidia-settings linux-headers
+  ensure_pacman_pkgs nvidia-open-dkms nvidia-utils nvidia-settings linux-headers
 fi
 
 print_success_message "NVIDIA drivers ready"

--- a/scripts/setup-voxtype.sh
+++ b/scripts/setup-voxtype.sh
@@ -96,7 +96,7 @@ fi
 # NVIDIA has a CUDA-accelerated Parakeet backend, which is faster and more
 # accurate than the default Whisper model. Check for a working driver
 # (nvidia-smi), not just NVIDIA PCI hardware — a card with no driver
-# installed (e.g. INSTALL_NVIDIA=false, or nouveau) has no CUDA to use.
+# installed (e.g. the nvidia catalog item was never selected, or nouveau) has no CUDA to use.
 if command -v nvidia-smi &> /dev/null && nvidia-smi &> /dev/null; then
     print_info_message "NVIDIA driver detected — downloading and activating the Parakeet model"
     voxtype setup --download --model parakeet-tdt-0.6b-v3 --activate --no-post-install || print_warning_message "voxtype setup --download (parakeet) failed — run it manually to fetch the speech model"

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -107,11 +107,9 @@ done
 mkdir -p "$(bootstrap_config_dir)"
 
 SAVED_PROFILES=""
-SAVED_NVIDIA=""
 SAVED_MACHINE_TYPE=""
 if load_bootstrap_config; then
   SAVED_PROFILES="${SETUP_PROFILES:-}"
-  SAVED_NVIDIA="${INSTALL_NVIDIA:-}"
   SAVED_MACHINE_TYPE="${MACHINE_TYPE:-}"
 fi
 
@@ -165,13 +163,6 @@ SETUP_PROFILE="$(primary_setup_profile)"
 if ! validate_bootstrap_profile; then
   print_error_message "Profiles must be a non-empty subset of work|personal|devcontainer (got: ${SETUP_PROFILES:-})"
   exit 1
-fi
-
-INSTALL_NVIDIA="${SAVED_NVIDIA:-}"
-if [ -z "$INSTALL_NVIDIA" ] || [ "$FORCE_PROMPT" = true ]; then
-  resolve_nvidia_preference
-else
-  print_info_message "Using INSTALL_NVIDIA: $(fmt_choice "$INSTALL_NVIDIA")"
 fi
 
 MACHINE_TYPE="${SAVED_MACHINE_TYPE:-}"


### PR DESCRIPTION
## Summary
- Capability is now first-class in the Catalog Engine: `catalog.Gaps`/`catalog.Available` evaluate an item's declared capabilities against detected machine facts (`catalog.Capabilities`), and `Select`/`SelectCategory` refuse or skip items whose requirements aren't met.
- The Install/Uninstall Software screen shows a capability-gated item disabled with its plain-language reason instead of hiding it, and refuses to toggle it on.
- The System Adapter gained `HasNVIDIAHardware` (mirroring `fn-lib.sh`'s `has_nvidia_hardware`) to detect the `nvidia-gpu` capability.
- The NVIDIA driver becomes an ordinary catalog item (`dfa/catalog/items/nvidia.toml`), gated on that capability; `setup-nvidia.sh` gained the same `--install`/`--uninstall` System Adapter convention as `setup-essentials.sh`.
- `INSTALL_NVIDIA` is no longer read from or written to the bootstrap config — direct invocation (`run-profile-setup.sh`) now auto-installs purely from hardware/package detection.

Closes #40.

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` (dfa module)
- [x] `bash scripts/check.sh` (bash -n + shellcheck)
- [x] Manually loaded the real catalog dir to confirm `nvidia.toml` parses correctly

Note: per the existing `dashboard.go` comment ("later tickets grow the rest of the taxonomy"), the live `dfa` dashboard still only browses the `essentials` category — the `hardware`/`nvidia` item isn't reachable from the top-level TUI yet, consistent with how #39 left category browsing as future work. Capability gating itself is fully implemented and tested at the engine/screen level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFnHa8g8ak7bxW7uoi1hdf