### PR TITLE
feat(dfa): confirm cascade-deselect before applying, proven with Docker -> Minikube (#41)

### DIFF
--- a/dfa/catalog/items/docker.toml
+++ b/dfa/catalog/items/docker.toml
@@ -1,0 +1,12 @@
+id = "docker"
+name = "Docker"
+description = "Container engine (Docker Engine, CLI, Compose, Buildx, lazydocker)."
+categories = ["development"]
+tier = "optional"
+capabilities = []
+dependencies = []
+setup_script = "setup-docker.sh"
+
+[packages]
+pacman = ["docker", "docker-compose", "docker-buildx", "lazydocker"]
+aur = []

--- a/dfa/catalog/items/minikube.toml
+++ b/dfa/catalog/items/minikube.toml
@@ -1,0 +1,12 @@
+id = "minikube"
+name = "Minikube"
+description = "Local Kubernetes cluster (minikube, kubectl, k9s)."
+categories = ["development"]
+tier = "optional"
+capabilities = []
+dependencies = ["docker"]
+setup_script = "setup-minikube.sh"
+
+[packages]
+pacman = ["minikube", "kubectl", "k9s"]
+aur = []

--- a/dfa/internal/software/software.go
+++ b/dfa/internal/software/software.go
@@ -60,6 +60,11 @@ type Model struct {
 	runner       ScriptRunner
 	cursor       int
 	statusMsg    string
+	// pendingPlan holds a computed cascade-deselect plan awaiting user
+	// confirmation (y/n) before it's applied — set whenever Deselect or
+	// DeselectCategory would also remove other selected dependents, so the
+	// user sees the full list before anything is uninstalled.
+	pendingPlan *catalog.Plan
 }
 
 // New builds a software Model scoped to one category, starting from the
@@ -86,6 +91,16 @@ func (m Model) Init() tea.Cmd { return nil }
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	keyMsg, ok := msg.(tea.KeyMsg)
 	if !ok {
+		return m, nil
+	}
+
+	if m.pendingPlan != nil {
+		switch keyMsg.String() {
+		case "y", "enter":
+			m.confirmPending()
+		case "n", "esc":
+			m.cancelPending()
+		}
 		return m, nil
 	}
 
@@ -132,16 +147,50 @@ func (m *Model) toggleCurrent() {
 			m.statusMsg = capabilityUnavailableMessage(item, gaps)
 			return
 		}
+		plan, err := catalog.Select(m.manifest, m.selection, item.ID, m.capabilities)
+		m.applyPlanOrError(plan, err)
+		return
 	}
 
-	var plan catalog.Plan
-	var err error
-	if m.selection[item.ID] {
-		plan, err = catalog.Deselect(m.manifest, m.selection, item.ID)
-	} else {
-		plan, err = catalog.Select(m.manifest, m.selection, item.ID, m.capabilities)
+	plan, err := catalog.Deselect(m.manifest, m.selection, item.ID)
+	if err != nil {
+		m.statusMsg = err.Error()
+		return
 	}
-	m.applyPlanOrError(plan, err)
+	m.confirmOrApply(plan)
+}
+
+// confirmOrApply runs plan immediately unless it would also deselect other
+// currently-selected dependents, in which case it's held as pendingPlan and
+// the full cascade list is shown to the user first — nothing is uninstalled
+// until they confirm with "y"/enter, or discarded with "n"/esc.
+func (m *Model) confirmOrApply(plan catalog.Plan) {
+	if len(plan.CascadeDeselected) > 0 {
+		m.pendingPlan = &plan
+		m.statusMsg = cascadeConfirmMessage(plan.CascadeDeselected)
+		return
+	}
+	m.runPlan(plan)
+}
+
+// cascadeConfirmMessage renders the confirmation prompt listing every extra
+// item a cascade-deselect would also remove.
+func cascadeConfirmMessage(cascade []string) string {
+	return fmt.Sprintf("Also removing (depends on this): %s — confirm? (y/n)", strings.Join(cascade, ", "))
+}
+
+func (m *Model) confirmPending() {
+	if m.pendingPlan == nil {
+		return
+	}
+	plan := *m.pendingPlan
+	m.pendingPlan = nil
+	m.runPlan(plan)
+}
+
+func (m *Model) cancelPending() {
+	m.pendingPlan = nil
+	m.statusMsg = "Cancelled — selection unchanged"
 }
 
 // capabilityUnavailableMessage renders the status-bar explanation for why a
@@ -167,7 +216,11 @@ func (m *Model) selectAll() {
 
 func (m *Model) deselectAll() {
 	plan, err := catalog.DeselectCategory(m.manifest, m.selection, m.category)
-	m.applyPlanOrError(plan, err)
+	if err != nil {
+		m.statusMsg = err.Error()
+		return
+	}
+	m.confirmOrApply(plan)
 }
 
 func (m *Model) applyPlanOrError(plan catalog.Plan, err error) {
@@ -279,6 +332,10 @@ func (m Model) View() string {
 		b.WriteString("\n")
 	}
 
-	b.WriteString(helpStyle.Render("space: toggle  •  a: select all  •  u: deselect all  •  esc: back"))
+	help := "space: toggle  •  a: select all  •  u: deselect all  •  esc: back"
+	if m.pendingPlan != nil {
+		help = "y: confirm removal  •  n: cancel"
+	}
+	b.WriteString(helpStyle.Render(help))
 	return b.String()
 }

--- a/dfa/internal/software/software_test.go
+++ b/dfa/internal/software/software_test.go
@@ -61,6 +61,18 @@ func fixtureManifest(t *testing.T) catalog.Manifest {
 			Capabilities: []string{"nvidia-gpu"}, SetupScript: "setup-nvidia.sh",
 			Packages: catalog.Packages{Pacman: []string{"nvidia-open-dkms"}},
 		},
+		{
+			ID: "docker", Name: "docker", Description: "Container engine",
+			Categories: []string{"development"}, Tier: catalog.TierOptional,
+			SetupScript: "setup-docker.sh",
+			Packages:    catalog.Packages{Pacman: []string{"docker"}},
+		},
+		{
+			ID: "minikube", Name: "minikube", Description: "Local Kubernetes cluster",
+			Categories: []string{"development"}, Tier: catalog.TierOptional,
+			Dependencies: []string{"docker"}, SetupScript: "setup-minikube.sh",
+			Packages: catalog.Packages{Pacman: []string{"minikube"}},
+		},
 	})
 	if err != nil {
 		t.Fatalf("NewManifest() error = %v", err)
@@ -296,6 +308,131 @@ func TestView_ShowsDisabledCapabilityGatedItemWithReason(t *testing.T) {
 	view := m.View()
 	if !strings.Contains(view, "unavailable") || !strings.Contains(view, "No NVIDIA GPU detected on this machine") {
 		t.Errorf("View() = %q, want it to show the item disabled with its unmet-capability reason", view)
+	}
+}
+
+func TestUpdate_DeselectDependencyWithSelectedDependentAsksConfirmationFirst(t *testing.T) {
+	runner := &fakeRunner{}
+	current := catalog.Selection{"docker": true, "minikube": true}
+	m := New(fixtureManifest(t), "development", current, runner, nil)
+	m.cursor = 0 // docker
+
+	updated, _ := m.Update(keyMsg(" "))
+	m = updated.(Model)
+
+	if !m.selection["docker"] || !m.selection["minikube"] {
+		t.Errorf("selection = %v, want unchanged until the cascade is confirmed", m.selection)
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("calls = %+v, want none until confirmed", runner.calls)
+	}
+	if !strings.Contains(m.statusMsg, "minikube") {
+		t.Errorf("statusMsg = %q, want it to name the cascaded dependent", m.statusMsg)
+	}
+}
+
+func TestUpdate_ConfirmingCascadeAppliesBothUninstalls(t *testing.T) {
+	runner := &fakeRunner{}
+	current := catalog.Selection{"docker": true, "minikube": true}
+	m := New(fixtureManifest(t), "development", current, runner, nil)
+	m.cursor = 0 // docker
+
+	updated, _ := m.Update(keyMsg(" "))
+	m = updated.(Model)
+	updated, _ = m.Update(keyMsg("y"))
+	m = updated.(Model)
+
+	if m.selection["docker"] || m.selection["minikube"] {
+		t.Errorf("selection = %v, want both deselected after confirming", m.selection)
+	}
+	want := []scriptCall{
+		{script: "setup-docker.sh", args: []string{"--uninstall", "docker"}},
+		{script: "setup-minikube.sh", args: []string{"--uninstall", "minikube"}},
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Errorf("calls = %+v, want %+v", runner.calls, want)
+	}
+}
+
+func TestUpdate_CancellingCascadeLeavesSelectionAndSkipsScripts(t *testing.T) {
+	runner := &fakeRunner{}
+	current := catalog.Selection{"docker": true, "minikube": true}
+	m := New(fixtureManifest(t), "development", current, runner, nil)
+	m.cursor = 0 // docker
+
+	updated, _ := m.Update(keyMsg(" "))
+	m = updated.(Model)
+	updated, _ = m.Update(keyMsg("n"))
+	m = updated.(Model)
+
+	if !m.selection["docker"] || !m.selection["minikube"] {
+		t.Errorf("selection = %v, want unchanged after cancelling", m.selection)
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("calls = %+v, want none after cancelling", runner.calls)
+	}
+	if m.pendingPlan != nil {
+		t.Errorf("pendingPlan = %+v, want nil after cancelling", m.pendingPlan)
+	}
+}
+
+func TestUpdate_SelectDependentAutoSelectsDependencyWithoutConfirmation(t *testing.T) {
+	runner := &fakeRunner{}
+	m := New(fixtureManifest(t), "development", catalog.Selection{}, runner, nil)
+	m.cursor = 1 // minikube
+
+	updated, _ := m.Update(keyMsg(" "))
+	m = updated.(Model)
+
+	if !m.selection["docker"] || !m.selection["minikube"] {
+		t.Errorf("selection = %v, want both docker and minikube selected", m.selection)
+	}
+	want := []scriptCall{
+		{script: "setup-docker.sh", args: []string{"--install", "docker"}},
+		{script: "setup-minikube.sh", args: []string{"--install", "minikube"}},
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Errorf("calls = %+v, want %+v", runner.calls, want)
+	}
+}
+
+func TestUpdate_DeselectAllCascadeAsksConfirmationFirst(t *testing.T) {
+	runner := &fakeRunner{}
+	current := catalog.Selection{"docker": true, "minikube": true}
+	m := New(fixtureManifest(t), "development", current, runner, nil)
+
+	updated, _ := m.Update(keyMsg("u"))
+	m = updated.(Model)
+
+	if !m.selection["docker"] || !m.selection["minikube"] {
+		t.Errorf("selection = %v, want unchanged until confirmed", m.selection)
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("calls = %+v, want none until confirmed", runner.calls)
+	}
+
+	updated, _ = m.Update(keyMsg("y"))
+	m = updated.(Model)
+
+	if m.selection["docker"] || m.selection["minikube"] {
+		t.Errorf("selection = %v, want both deselected after confirming", m.selection)
+	}
+	if len(runner.calls) != 2 {
+		t.Errorf("len(calls) = %d, want 2 after confirming", len(runner.calls))
+	}
+}
+
+func TestView_ShowsCascadeConfirmationHelp(t *testing.T) {
+	current := catalog.Selection{"docker": true, "minikube": true}
+	m := New(fixtureManifest(t), "development", current, &fakeRunner{}, nil)
+	m.cursor = 0 // docker
+
+	updated, _ := m.Update(keyMsg(" "))
+	m = updated.(Model)
+
+	view := m.View()
+	if !strings.Contains(view, "confirm removal") {
+		t.Errorf("View() = %q, want it to show the confirm/cancel help", view)
 	}
 }
 

--- a/scripts/setup-docker.sh
+++ b/scripts/setup-docker.sh
@@ -21,8 +21,64 @@ else
 fi
 
 # --------------------------
-# End Import Common Header 
+# End Import Common Header
 # --------------------------
+
+# docker_target_user / docker_ensure_ready are shared by both the catalog
+# dispatch below and the direct-invocation flow further down, so there is
+# exactly one place that decides who to add to the docker group and how.
+docker_target_user() {
+  if [ -n "${SUDO_USER-}" ]; then
+    echo "$SUDO_USER"
+  else
+    echo "$USER"
+  fi
+}
+
+# Enables/starts the docker service and adds the target user to the docker
+# group if not already a member. Idempotent — safe to call every run.
+docker_ensure_ready() {
+  sudo systemctl enable --now docker
+  local target_user
+  target_user="$(docker_target_user)"
+  if ! groups "$target_user" | grep -q docker; then
+    print_info_message "Adding user '$target_user' to docker group"
+    sudo usermod -aG docker "$target_user"
+    print_warning_message "You need to log out and log back in for group changes to take effect"
+  fi
+}
+
+# --install / --uninstall <packages...>
+#   The dfa Catalog Engine's System Adapter path — the "docker" catalog item
+#   (dfa/catalog/items/docker.toml). Installs/removes exactly the given
+#   pacman packages via the shared ensure_pacman_pkgs/remove_pacman_pkgs
+#   helpers; --install also brings the service/group up (skipped if the
+#   package install failed) so a dfa-driven install is actually usable, not
+#   just packages on disk.
+case "${1:-}" in
+  --install)
+    shift
+    ensure_pacman_pkgs "$@"
+    status=$?
+    if [ "$status" -eq 0 ] && command -v docker >/dev/null 2>&1; then
+      docker_ensure_ready
+    fi
+    exit $status
+    ;;
+  --uninstall)
+    shift
+    target_user="$(docker_target_user)"
+    if groups "$target_user" | grep -q docker; then
+      print_info_message "Removing user '$target_user' from docker group"
+      sudo gpasswd -d "$target_user" docker >/dev/null 2>&1 || true
+    fi
+    if command -v docker >/dev/null 2>&1; then
+      sudo systemctl disable --now docker >/dev/null 2>&1 || true
+    fi
+    remove_pacman_pkgs "$@"
+    exit $?
+    ;;
+esac
 
 print_tool_setup_start "Docker"
 
@@ -33,19 +89,7 @@ print_tool_setup_start "Docker"
 # Check to see if Docker is already installed and working
 if command -v docker >/dev/null 2>&1 && docker --version >/dev/null 2>&1; then
   print_info_message "Docker is already installed and working."
-
-  # Ensure user is in docker group
-  if [ -n "${SUDO_USER-}" ]; then
-    TARGET_USER="$SUDO_USER"
-  else
-    TARGET_USER="$USER"
-  fi
-
-  if ! groups "$TARGET_USER" | grep -q docker; then
-    print_info_message "Adding user '$TARGET_USER' to docker group"
-    sudo usermod -aG docker "$TARGET_USER"
-    print_warning_message "You need to log out and log back in for group changes to take effect"
-  fi
+  docker_ensure_ready
 
   print_tool_setup_complete "Docker"
   exit 0
@@ -66,27 +110,10 @@ remove_pacman_pkgs docker-compose podman podman-docker
 print_info_message "Installing Docker Engine, CLI, and plugins"
 sudo pacman -S --needed --noconfirm docker docker-compose docker-buildx
 # --------------------------
-# Configure and Start Docker Service
+# Configure and Start Docker Service, Add User to Group
 # --------------------------
 
-# Start and enable Docker service
-print_info_message "Starting and enabling Docker service"
-sudo systemctl start docker
-sudo systemctl enable --now docker
-
-# --------------------------
-# Add User to Docker Group
-# --------------------------
-
-# Add original user (when run with sudo) or current user to the docker group
-if [ -n "${SUDO_USER-}" ]; then
-  TARGET_USER="$SUDO_USER"
-else
-  TARGET_USER="$USER"
-fi
-
-print_info_message "Adding user '$TARGET_USER' to docker group"
-sudo usermod -aG docker "$TARGET_USER"
+docker_ensure_ready
 
 # --------------------------
 # Install Lazy Docker

--- a/scripts/setup-minikube.sh
+++ b/scripts/setup-minikube.sh
@@ -24,6 +24,25 @@ fi
 # End Import Common Header
 # --------------------------
 
+# --install / --uninstall <packages...>
+#   The dfa Catalog Engine's System Adapter path — the "minikube" catalog
+#   item (dfa/catalog/items/minikube.toml, depends on "docker"). Installs/
+#   removes exactly the given pacman packages via the shared
+#   ensure_pacman_pkgs/remove_pacman_pkgs helpers, same convention as
+#   setup-essentials.sh / setup-nvidia.sh.
+case "${1:-}" in
+  --install)
+    shift
+    ensure_pacman_pkgs "$@"
+    exit $?
+    ;;
+  --uninstall)
+    shift
+    remove_pacman_pkgs "$@"
+    exit $?
+    ;;
+esac
+
 print_tool_setup_start "Minikube"
 
 # --------------------------


### PR DESCRIPTION
## Summary
- The Catalog Engine already resolved dependency auto-select and cascade-deselect (#39/#40), but the software TUI applied a cascade-deselect immediately with no confirmation. Now the plan is held as `pendingPlan` and the full cascade list is shown first — `y`/enter applies it, `n`/esc discards it with nothing touched.
- Added `docker`/`minikube` as the first real dependency pair in the catalog (`minikube` depends on `docker`), with working `--install`/`--uninstall` in their setup scripts, extracting a shared `docker_ensure_ready` helper so the catalog dispatch and the existing direct-invocation flow don't duplicate group/service setup.

Closes #41

## Test plan
- [x] `bash scripts/check.sh` (bash -n + shellcheck)
- [x] `go test ./...` in `dfa/`
- [x] Ran a two-axis (Standards + Spec) code review and fixed the findings (duplicated group-add logic, install side effects running after a failed package install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFnHa8g8ak7bxW7uoi1hdf