### PR TITLE
fix(claude): allowlist npm lifecycle scripts before installing Claude Code

### DIFF
--- a/scripts/setup-claude.sh
+++ b/scripts/setup-claude.sh
@@ -25,6 +25,9 @@ fi
 if command -v claude &>/dev/null; then
   print_info_message "Claude Code is already installed: $(command -v claude)"
 else
+  # npm blocks lifecycle scripts by default; @anthropic-ai/claude-code needs
+  # its postinstall to run, so explicitly allowlist it (user-level npmrc).
+  npm config set allow-scripts=@anthropic-ai/claude-code --location=user
   print_action_message "Installing Claude Code via user npm (no sudo)"
   npm install -g @anthropic-ai/claude-code
 fi


### PR DESCRIPTION
## Summary
- npm now blocks package lifecycle scripts by default, which was causing `@anthropic-ai/claude-code`'s postinstall to be skipped on a fresh install.
- `setup-claude.sh` now runs `npm config set allow-scripts=@anthropic-ai/claude-code --location=user` before installing, so bootstrap/sync no longer requires the manual workaround.

## Test plan
- [x] `bash scripts/check.sh` (bash -n + shellcheck)