### PR TITLE
feat(bin): responsive fzf picker layout for dfa

### DIFF
--- a/home/.local/bin/dfa
+++ b/home/.local/bin/dfa
@@ -17,23 +17,27 @@ _LIB_DIR="$(cd -- "$(dirname -- "$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null |
 # shellcheck source=/dev/null
 [[ -r "$_LIB_DIR/dotfiles-arch-lib.sh" ]] && source "$_LIB_DIR/dotfiles-arch-lib.sh"
 
-# name | how-often | one-line summary | longer explanation (used in fzf preview)
+# name | badge | how-often | one-line summary | longer explanation (used in fzf preview)
+#
+# "badge" is a short (~1-3 word) tag for the picker row itself — the row has
+# no room for prose, so it never truncates mid-sentence. "how-often" is the
+# fuller cadence/trigger text shown in the preview pane's "How often" line.
 #
 # Ordered most-to-least frequent. "How often" is a rough habit guide, not a
 # hard rule — edit freely as your own routine settles.
 DFA_COMMANDS=(
-  "morning|Daily|Your one command each morning: pull repos, update packages, resync skills/rules/agents|Runs dfa-update-repos, dfa-update-system, dfa-sync-skills, dfa-sync-rules, dfa-sync-harness-agents in order (edit MORNING_STEPS in ~/.local/bin/dfa-morning to change the list). If dfa-update-repos pulls new dotfiles-arch commits, it automatically runs dfa-sync-dotfiles for you and restarts once so the remaining steps see the freshly-synced scripts. This is the everyday driver — you almost never need to reach for the individual steps below by hand."
-  "sync-dotfiles|After editing dotfiles-arch, or if morning's auto-resync fails|Apply THIS repo's setup scripts + symlinks to your machine|Re-runs the setup-*.sh scripts for your saved profile and re-links home/ + config/ into \$HOME (scripts/sync.sh). dfa-morning already calls this automatically whenever it notices dotfiles-arch itself moved forward. Run it directly only when you want that applied right now without also updating packages/repos — e.g. you just committed a setup-script change on this machine, or dfa-morning's auto-resync step failed and you want to retry it alone."
-  "update-repos|Daily (via morning)|git pull --ff-only every repo under ~/repos, in parallel|Skips any repo with a dirty working tree; MAX_PARALLEL (default 8) controls concurrency. This is the step in dfa-morning that notices when dotfiles-arch itself has new commits."
-  "update-system|Daily (via morning)|Guarded pacman + yay update, with an AUR IoC scan|Rate-limited day-to-day system package updater. dfa-morning always runs this; run it alone if you just want packages current without touching repos or skills/rules."
-  "sync-skills|Daily (via morning)|Relink personal Claude/Cursor skills from dotfiles-arch|Symlinks skills/* from dotfiles-arch plus any extra sources (dfa-sync-sources) into ~/.claude/skills and ~/.cursor/skills, pruning stale links. Part of dfa-morning; run alone after editing a skill locally if you don't want a full morning run."
-  "sync-rules|Daily (via morning)|Relink personal Cursor rules from dotfiles-arch|Symlinks rules/* from dotfiles-arch plus extra sources into ~/.cursor/rules (and, for alwaysApply rules, a ~/.claude/dfa-rules-*.md import), pruning stale links. Part of dfa-morning; run alone after editing a rule locally."
-  "sync-harness-agents|Daily (via morning)|Sync locally-pulled Ollama models into Codex + opencode's model lists|Regenerates the managed ollama-* profile/provider blocks in ~/.codex/config.toml and ~/.config/opencode/opencode.jsonc from 'ollama list'. Part of dfa-morning; run alone right after an 'ollama pull'/'ollama rm' if you don't want to wait for the next morning run."
-  "repos|Whenever you're jumping between projects|Pick a repo under ~/repos with fzf and cd into it|Prints the picked path — use as: cd \"\$(dfa-repos)\" (the r alias does this for you). Two levels deep, .git-aware; also lists non-git folders as browse targets."
-  "refresh-audio|After docking/undocking or resuming from suspend|Restart the PipeWire/WirePlumber stack to clear duplicate audio devices|Restarts wireplumber, pipewire, and pipewire-pulse (user services) — fixes duplicate sink/source entries in wpctl status and GNOME's speaker/mic quick-settings menus. --status just prints wpctl status without restarting anything."
-  "remove-orphans|Occasionally, after removing packages|Remove orphaned pacman packages (pacman -Qtdq)|Aliased as: orphans."
-  "check-dotfiles|Before committing a script change|Syntax-check + shellcheck the dotfiles-arch scripts|Runs scripts/check.sh (bash -n + shellcheck -x) over the repo. Aliased as: check."
-  "sync-sources|Rare — one-time setup per extra source repo|List, add, or remove extra rules/skills source repos|Manages ~/.config/dotfiles-arch/sync-sources, the list of non-dotfiles-arch repos that dfa-sync-skills / dfa-sync-rules also pull from."
+  "morning|Daily|Daily|Your one command each morning: pull repos, update packages, resync skills/rules/agents|Runs dfa-update-repos, dfa-update-system, dfa-sync-skills, dfa-sync-rules, dfa-sync-harness-agents in order (edit MORNING_STEPS in ~/.local/bin/dfa-morning to change the list). If dfa-update-repos pulls new dotfiles-arch commits, it automatically runs dfa-sync-dotfiles for you and restarts once so the remaining steps see the freshly-synced scripts. This is the everyday driver — you almost never need to reach for the individual steps below by hand."
+  "sync-dotfiles|As needed|After editing dotfiles-arch, or if morning's auto-resync fails|Apply THIS repo's setup scripts + symlinks to your machine|Re-runs the setup-*.sh scripts for your saved profile and re-links home/ + config/ into \$HOME (scripts/sync.sh). dfa-morning already calls this automatically whenever it notices dotfiles-arch itself moved forward. Run it directly only when you want that applied right now without also updating packages/repos — e.g. you just committed a setup-script change on this machine, or dfa-morning's auto-resync step failed and you want to retry it alone."
+  "update-repos|Daily · via morning|Daily (via morning)|git pull --ff-only every repo under ~/repos, in parallel|Skips any repo with a dirty working tree; MAX_PARALLEL (default 8) controls concurrency. This is the step in dfa-morning that notices when dotfiles-arch itself has new commits."
+  "update-system|Daily · via morning|Daily (via morning)|Guarded pacman + yay update, with an AUR IoC scan|Rate-limited day-to-day system package updater. dfa-morning always runs this; run it alone if you just want packages current without touching repos or skills/rules."
+  "sync-skills|Daily · via morning|Daily (via morning)|Relink personal Claude/Cursor skills from dotfiles-arch|Symlinks skills/* from dotfiles-arch plus any extra sources (dfa-sync-sources) into ~/.claude/skills and ~/.cursor/skills, pruning stale links. Part of dfa-morning; run alone after editing a skill locally if you don't want a full morning run."
+  "sync-rules|Daily · via morning|Daily (via morning)|Relink personal Cursor rules from dotfiles-arch|Symlinks rules/* from dotfiles-arch plus extra sources into ~/.cursor/rules (and, for alwaysApply rules, a ~/.claude/dfa-rules-*.md import), pruning stale links. Part of dfa-morning; run alone after editing a rule locally."
+  "sync-harness-agents|Daily · via morning|Daily (via morning)|Sync locally-pulled Ollama models into Codex + opencode's model lists|Regenerates the managed ollama-* profile/provider blocks in ~/.codex/config.toml and ~/.config/opencode/opencode.jsonc from 'ollama list'. Part of dfa-morning; run alone right after an 'ollama pull'/'ollama rm' if you don't want to wait for the next morning run."
+  "repos|Often|Whenever you're jumping between projects|Pick a repo under ~/repos with fzf and cd into it|Prints the picked path — use as: cd \"\$(dfa-repos)\" (the r alias does this for you). Two levels deep, .git-aware; also lists non-git folders as browse targets."
+  "refresh-audio|On dock event|After docking/undocking or resuming from suspend|Restart the PipeWire/WirePlumber stack to clear duplicate audio devices|Restarts wireplumber, pipewire, and pipewire-pulse (user services) — fixes duplicate sink/source entries in wpctl status and GNOME's speaker/mic quick-settings menus. --status just prints wpctl status without restarting anything."
+  "remove-orphans|Occasional|Occasionally, after removing packages|Remove orphaned pacman packages (pacman -Qtdq)|Aliased as: orphans."
+  "check-dotfiles|Pre-commit|Before committing a script change|Syntax-check + shellcheck the dotfiles-arch scripts|Runs scripts/check.sh (bash -n + shellcheck -x) over the repo. Aliased as: check."
+  "sync-sources|Rare|Rare — one-time setup per extra source repo|List, add, or remove extra rules/skills source repos|Manages ~/.config/dotfiles-arch/sync-sources, the list of non-dotfiles-arch repos that dfa-sync-skills / dfa-sync-rules also pull from."
 )
 
 usage() {
@@ -63,17 +67,17 @@ resolve_command() {
 }
 
 print_table() {
-  local entry name freq short
+  local entry name badge freq short
   for entry in "${DFA_COMMANDS[@]}"; do
-    IFS='|' read -r name freq short _ <<<"$entry"
+    IFS='|' read -r name badge freq short _ <<<"$entry"
     printf '%-22s %-30s %s\n' "dfa-$name" "$freq" "$short"
   done
 }
 
 preview_for() {
-  local target="$1" entry name freq short long width="${FZF_PREVIEW_COLUMNS:-76}"
+  local target="$1" entry name badge freq short long width="${FZF_PREVIEW_COLUMNS:-76}"
   for entry in "${DFA_COMMANDS[@]}"; do
-    IFS='|' read -r name freq short long <<<"$entry"
+    IFS='|' read -r name badge freq short long <<<"$entry"
     if [[ "$name" == "$target" ]]; then
       printf 'dfa-%s\n\nHow often: %s\n\n%s\n' "$name" "$freq" "$long" | fold -s -w "$width"
       return 0
@@ -93,13 +97,34 @@ run_picker() {
     exit 1
   fi
 
-  local entry name freq short lines=()
+  # Row = name + a short status badge only. The full "how often" text and
+  # the long explanation live in the preview pane, not the row — a row that
+  # also tried to fit a one-line summary (or a full-sentence badge) is what
+  # used to truncate into "··" at normal terminal widths. The name column
+  # width is sized to the longest command name so the badge always lines up
+  # in its own column instead of butting up against a long name.
+  local entry name badge name_w=0 lines=()
   for entry in "${DFA_COMMANDS[@]}"; do
-    IFS='|' read -r name freq short _ <<<"$entry"
-    lines+=("$(printf '%-22s %-30s %s' "dfa-$name" "$freq" "$short")")
+    IFS='|' read -r name _ _ _ _ <<<"$entry"
+    (( ${#name} + 6 > name_w )) && name_w=$(( ${#name} + 6 ))
+  done
+  for entry in "${DFA_COMMANDS[@]}"; do
+    IFS='|' read -r name badge _ _ _ <<<"$entry"
+    lines+=("$(printf "%-${name_w}s %s" "dfa-$name" "$badge")")
   done
 
   clear >/dev/tty
+
+  # Side-by-side preview needs room for both the list and readable prose;
+  # below that width, stack the preview under the list instead so its text
+  # wraps at full terminal width rather than clipping in a squeezed column.
+  local cols preview_window
+  cols="$(tput cols 2>/dev/null || echo "${COLUMNS:-80}")"
+  if (( cols >= 100 )); then
+    preview_window='right:60%'
+  else
+    preview_window='down:55%'
+  fi
 
   local selected
   selected="$(printf '%s\n' "${lines[@]}" \
@@ -107,7 +132,7 @@ run_picker() {
           --prompt='dfa> ' \
           --header='pick a command — preview explains what it does and when to use it' \
           --preview="echo {1} | sed 's/^dfa-//' | xargs -I{} \"$0\" __preview__ {}" \
-          --preview-window=right:60%)"
+          --preview-window="$preview_window")"
 
   [[ -z "$selected" ]] && exit 0
   awk '{print $1}' <<<"$selected"


### PR DESCRIPTION
## Summary
- Add a short dedicated `badge` field per command (e.g. "Daily", "As needed", "On dock event") so picker rows show name + a compact tag instead of a long freq/trigger sentence that truncated into "··"
- Size the name column to the longest command name so the badge column stays aligned instead of butting against long names
- Switch the preview pane between a right-hand split (≥100 columns) and stacking below the list (<100 columns), so preview text wraps at full width on narrow/half-screen terminals instead of clipping in a squeezed column

## Test plan
- [x] `bash scripts/check.sh` (bash -n + shellcheck) passes
- [x] `dfa list` output unchanged (still uses the fuller freq/short text)
- [x] `dfa __preview__ <name>` output unchanged
- [x] Simulated row output confirms no truncation and consistent column alignment across all 12 commands
- [x] Verified preview-window threshold logic (right:60% at ≥100 cols, down:55% below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y3Vtfr2pHDRAAAhFs3ciYk