### PR TITLE
feat(git): keep ~/.gitconfig machine-local, share settings via XDG config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,10 +28,10 @@ dotfiles-arch/
 │   └── setup-*.sh                # Individual tool setup scripts
 ├── home/                         # Dotfiles for ~/
 │   ├── .bashrc
-│   ├── .gitconfig                # Shared only; includes ~/.config/git/identity
 │   ├── .packages.md              # → ../PACKAGES.md (shown by `packages`)
 │   └── .local/bin/               # Helpers (code, zed-agent-init, dfa — fzf picker over the dfa-* commands, dfa-repos, dfa-check-dotfiles, dfa-remove-orphans, dfa-sync-dotfiles, dfa-update-system, dfa-refresh-audio, …)
 ├── config/                       # ~/.config application configs
+│   ├── git/config                # Shared git settings (~/.gitconfig stays machine-local)
 │   ├── fontconfig/fonts.conf
 │   ├── nvim/
 │   ├── kitty/
@@ -148,7 +148,7 @@ Shared: Kitty, tmux, Claude Code, Codex, opencode, pi, Ollama, Neovim, languages
 ### Special cases
 
 - **prepare-archinstall.sh**: Run from the live ISO before archinstall, not from an installed system. Lists block devices via `lsblk` (excluding loop/optical, and `zram` specifically since it reports `TYPE=disk` too but isn't a real wipeable target), prompts for a hostname, and detects the GPU vendor via `has_nvidia_hardware`/`has_amd_gpu_hardware`/`has_intel_gpu_hardware` (`fn-lib.sh`, sourced defensively like `post_install.sh`) to propose one of the six canonical `gfx_driver` values (`archinstall/lib/hardware.py`'s `GfxDriver` enum, tag 4.4 — see `docs/research/archinstall-config-schema.md`), letting the user confirm or override. Requires typing the disk path a second time to confirm before it's willing to select it (the layout wipes the disk). Patches `disk_config.device_modifications[0].device`, `hostname`, and `profile_config.gfx_driver` into `user_configuration.json` via `python3 -c` (present on the ISO because archinstall itself needs it), preserving key order and the rest of the file untouched. `--dry-run` prints the same planned changes without writing. Never reads, writes, or references `user_credentials.json` — the LUKS/user password stays a manual step by deliberate choice.
-- **setup-git.sh**: Requires name + email args (no TTY → must pass args); writes `~/.config/git/identity` (not the shared `.gitconfig`)
+- **setup-git.sh**: Requires name + email args (no TTY → must pass args); writes identity into the real, machine-local `~/.gitconfig` (never symlinked). Shared settings live in `config/git/config` → `~/.config/git/config`, which git reads first so local values win; `git config --global`/`gh auth setup-git` also land in `~/.gitconfig`. `ensure_local_gitconfig` (`fn-lib.sh`, also called by `link-dotfiles.sh`) converts the legacy layout — replaces a `~/.gitconfig` symlink into the repo and folds `~/.config/git/identity` into it
 - **setup-node.sh / setup-claude.sh**: NVM at `~/.config/nvm` (checksummed install.sh, never `curl|bash`); Claude uses user-level `npm` (never `sudo npm`). `setup-claude.sh` also idempotently merges the `nvim-reveal-edit` `PostToolUse` hook into `~/.claude/settings.json` (jq, touching only `.hooks.PostToolUse`)
 - **setup-dev.sh**: Installs `tmux`, `lazygit`, `lazydocker` (the `dev --tmux` path; Zed itself comes from `setup-zed.sh`); runs last in `run-profile-setup.sh` (after profile extras) so all harness CLIs are already on PATH; resolves `DEFAULT_HARNESS` via `resolve_default_harness` — auto-picks the one harness CLI installed, prompts with a numbered list (Enter keeps the saved choice if it's still installed, else the first installed one) when 2+ are, leaves it empty when none are — and persists it with `write_bootstrap_config`
 - **setup-gnome.sh**: Only when `gnome-shell` is installed; power policy from `MACHINE_TYPE` (`power-profiles-daemon` profile, `/etc/systemd/logind.conf.d/dotfiles-arch-lid.conf` — laptop suspends on battery lid-close but ignores lid on AC/docked, `90-dotfiles-arch-usb-wakeup.rules` for KVM HID wake, audio powersave), falling back to `has_battery`; installs/configures Dash to Panel (always-visible full-width top bar, small centered icons, every monitor); Pop Shell auto-tiling off by default

--- a/config/git/config
+++ b/config/git/config
@@ -1,7 +1,8 @@
-# Shared Git config (symlinked). Per-machine identity lives in
-# ~/.config/git/identity — written by scripts/setup-git.sh.
-[include]
-	path = ~/.config/git/identity
+# Shared Git config — symlinked to ~/.config/git/config (git's XDG global file).
+# Machine-local settings (user.name/email, anything `git config --global` or
+# `gh auth setup-git` writes) live in the real ~/.gitconfig, which git reads
+# after this file, so local values win. See ensure_local_gitconfig (fn-lib.sh).
+# Never put identity here.
 [core]
 	editor = nvim
 	# Quoted so the semicolons are not read as git-config comments.
@@ -19,12 +20,11 @@
 	conflictStyle = zdiff3
 [diff]
 	colorMoved = default
+[fetch]
+	prune = true
 [init]
 	defaultBranch = main
 [credential "https://github.com"]
-    helper = !/usr/bin/gh auth git-credential
+	helper = !/usr/bin/gh auth git-credential
 [credential "https://gist.github.com"]
-    helper = !/usr/bin/gh auth git-credential
-[user]
-	name = Mike de la Fuente
-	email = mdelafuente@revolutionparts.com
+	helper = !/usr/bin/gh auth git-credential

--- a/scripts/fn-lib.sh
+++ b/scripts/fn-lib.sh
@@ -875,6 +875,50 @@ load_nvm() {
 }
 
 # --------------------------
+# Git
+# --------------------------
+
+# Shared settings are linked to ~/.config/git/config; ~/.gitconfig must be a
+# real machine-local file so identity and `git config --global` writes never
+# land in the repo. Converts the legacy layout (~/.gitconfig symlinked into the
+# repo + ~/.config/git/identity) in place. Idempotent.
+ensure_local_gitconfig() {
+  local target="$USER_HOME_DIR/.gitconfig"
+  local legacy_identity="$USER_HOME_DIR/.config/git/identity"
+  local key value
+
+  if [ -L "$target" ]; then
+    case "$(readlink "$target")" in
+      */home/.gitconfig)
+        print_action_message "Replacing legacy ~/.gitconfig symlink with a machine-local file"
+        rm -f "$target"
+        ;;
+      *)
+        print_warning_message "$target is a symlink not managed by dotfiles-arch — leaving it alone"
+        return 0
+        ;;
+    esac
+  fi
+
+  if [ ! -e "$target" ]; then
+    printf '%s\n' \
+      "# Machine-local Git config (not in dotfiles-arch). Shared settings come from" \
+      "# ~/.config/git/config; values here override them." > "$target"
+  fi
+
+  if [ -f "$legacy_identity" ]; then
+    for key in user.name user.email; do
+      if ! git config --file "$target" --get "$key" >/dev/null 2>&1 \
+        && value="$(git config --file "$legacy_identity" --get "$key" 2>/dev/null)"; then
+        git config --file "$target" "$key" "$value"
+      fi
+    done
+    rm -f "$legacy_identity"
+    print_info_message "Migrated $legacy_identity into $target"
+  fi
+}
+
+# --------------------------
 # Fonts
 # --------------------------
 

--- a/scripts/link-dotfiles.sh
+++ b/scripts/link-dotfiles.sh
@@ -71,7 +71,11 @@ link_path() {
 
 print_info_message "Linking home directory dotfiles..."
 
-for file in .bashrc .inputrc .profile .gitconfig .gitignore_global .nvim-cheatsheet.md .welcome.md .packages.md .tmux.conf; do
+# ~/.gitconfig is machine-local, not linked; shared git settings are
+# config/git/config (linked below with the rest of config/).
+ensure_local_gitconfig
+
+for file in .bashrc .inputrc .profile .gitignore_global .nvim-cheatsheet.md .welcome.md .packages.md .tmux.conf; do
   link_path "$DOTFILES_HOME_DIR/$file" "$USER_HOME_DIR/$file"
   print_info_message "Linked: $file"
 done

--- a/scripts/setup-git.sh
+++ b/scripts/setup-git.sh
@@ -77,27 +77,21 @@ fi
 # --------------------------
 # Configure Git Identity (machine-local)
 # --------------------------
-# Name/email are per-machine and must not live in the symlinked ~/.gitconfig.
-# Shared settings (editor, defaultBranch, credentials) come from home/.gitconfig.
-# Identity is written here and included via: [include] path = ~/.config/git/identity
+# Name/email are per-machine and live in the real (unlinked) ~/.gitconfig.
+# Shared settings (editor, defaultBranch, credentials) come from
+# config/git/config, linked to ~/.config/git/config by link-dotfiles.
 
 print_info_message "Writing machine-local Git identity"
 
-GIT_CONFIG_DIR="$USER_HOME_DIR/.config/git"
-IDENTITY_FILE="$GIT_CONFIG_DIR/identity"
+ensure_local_gitconfig
+LOCAL_GITCONFIG="$USER_HOME_DIR/.gitconfig"
+git config --file "$LOCAL_GITCONFIG" user.name "$USERNAME_ARG"
+git config --file "$LOCAL_GITCONFIG" user.email "$EMAIL_ARG"
 
-mkdir -p "$GIT_CONFIG_DIR"
-cat > "$IDENTITY_FILE" <<EOF
-[user]
-	name = $USERNAME_ARG
-	email = $EMAIL_ARG
-EOF
-
-print_info_message "Git identity written to $IDENTITY_FILE:"
+print_info_message "Git identity written to $LOCAL_GITCONFIG:"
 print_info_message "  Name: $USERNAME_ARG"
 print_info_message "  Email: $EMAIL_ARG"
-print_info_message "Shared settings (editor, defaultBranch) come from ~/.gitconfig after link-dotfiles"
-chmod 600 "$IDENTITY_FILE"
+print_info_message "Shared settings (editor, defaultBranch) come from ~/.config/git/config after link-dotfiles"
 
 # --------------------------
 # Setup SSH Keys


### PR DESCRIPTION
## Summary
- Move shared git settings from `home/.gitconfig` to `config/git/config` (linked to `~/.config/git/config`); drop the committed `[user]` block and the identity include.
- `~/.gitconfig` becomes a real machine-local file (identity, `git config --global`, `gh auth setup-git` writes) — git reads it after the XDG file, so local values win.
- New `ensure_local_gitconfig` in `fn-lib.sh` (called by `link-dotfiles.sh` and `setup-git.sh`) replaces the legacy symlink and migrates `~/.config/git/identity`.
- Enable `fetch.prune = true` by default.

## Rollout on other machines
Run `dfa daily` (or `dfa-sync-dotfiles` if already pulled). If `home/.gitconfig` is dirty in the clone, `git checkout home/.gitconfig` first so `dfa-update-repos` doesn't skip the pull.

## Test plan
- [x] `bash scripts/check.sh`
- [x] Ran `link-dotfiles.sh` locally; `git config --show-origin` shows identity from `~/.gitconfig`, shared settings from `~/.config/git/config`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yqFTLfVWdaJK1CigEKprH